### PR TITLE
Fixes Various Bugs Exposed by the Corpus Tester

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,7 @@ dependencies = [
  "indexmap",
  "itertools",
  "maplit",
+ "num-traits",
  "obj",
  "serde",
  "serde_plain",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,7 @@ dependencies = [
  "indicatif",
  "itertools",
  "libc",
+ "matches",
  "num_cpus",
  "serde",
  "serde_json",
@@ -477,6 +478,12 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "matches"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"

--- a/bve-build/src/main.rs
+++ b/bve-build/src/main.rs
@@ -32,6 +32,7 @@
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(clippy::missing_inline_in_public_items)]
 #![allow(clippy::module_name_repetitions)]
+#![allow(clippy::non_ascii_literal)]
 #![allow(clippy::option_expect_used)]
 #![allow(clippy::panic)]
 #![allow(clippy::print_stdout)] // This is a build script, not a fancy app

--- a/bve-corpus/Cargo.toml
+++ b/bve-corpus/Cargo.toml
@@ -22,6 +22,7 @@ clap = "2.33.0"
 indicatif = "0.13.0"
 itertools = "0.8.2"
 libc = "0.2.66"
+matches = "0.1.8"
 num_cpus = "1.12.0"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.45"

--- a/bve-corpus/src/bin/bve-parser-run.rs
+++ b/bve-corpus/src/bin/bve-parser-run.rs
@@ -1,5 +1,5 @@
 use bve::filesystem::read_convert_utf8;
-use bve::parse::mesh::mesh_from_str;
+use bve::parse::mesh::{mesh_from_str, MeshErrorKind};
 use clap::arg_enum;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
@@ -36,10 +36,14 @@ fn parse_mesh_b3d_csv(file: impl AsRef<Path>, errors: bool, b3d: bool) {
     };
 
     let start = Instant::now();
-    let parsed = mesh_from_str(&contents, file_type);
+    let mut parsed = mesh_from_str(&contents, file_type);
     let duration = Instant::now() - start;
 
     println!("Duration: {:.4}", duration.as_secs_f32());
+
+    parsed
+        .errors
+        .retain(|v| !matches!(v.kind, MeshErrorKind::UselessInstruction{..}));
 
     if errors {
         println!("Errors:");

--- a/bve-corpus/src/logger.rs
+++ b/bve-corpus/src/logger.rs
@@ -1,6 +1,7 @@
 use crate::{FileResult, Options, ParseResult};
 use crossbeam::channel::Receiver;
 use serde::Serialize;
+use std::cmp::Reverse;
 use std::fs::write;
 use std::path::PathBuf;
 
@@ -42,6 +43,10 @@ pub fn receive_results(options: &Options, result_source: &Receiver<FileResult>) 
             ParseResult::Finish => break,
         }
     }
+
+    results
+        .failures
+        .sort_by_cached_key(|v| Reverse((v.count, v.path.clone())));
 
     if let Some(output) = &options.output {
         write(output, serde_json::to_string_pretty(&results).unwrap()).unwrap();

--- a/bve-corpus/src/logger.rs
+++ b/bve-corpus/src/logger.rs
@@ -44,11 +44,17 @@ pub fn receive_results(options: &Options, result_source: &Receiver<FileResult>) 
         }
     }
 
+    results.failures.retain(|v| v.count != 0);
+
     results
         .failures
         .sort_by_cached_key(|v| Reverse((v.count, v.path.clone())));
 
+    println!("Panics: {}", results.panics.len());
+    println!("Failures: {}", results.failures.len());
+    println!("Successes: {}", results.successes.len());
+
     if let Some(output) = &options.output {
-        write(output, serde_json::to_string_pretty(&results).unwrap()).unwrap();
+        write(output, serde_json::to_string_pretty(&results.failures).unwrap()).unwrap();
     }
 }

--- a/bve-corpus/src/main.rs
+++ b/bve-corpus/src/main.rs
@@ -31,6 +31,7 @@
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(clippy::missing_inline_in_public_items)]
 #![allow(clippy::module_name_repetitions)]
+#![allow(clippy::non_ascii_literal)]
 #![allow(clippy::option_expect_used)]
 #![allow(clippy::panic)]
 #![allow(clippy::print_stdout)] // This is a build script, not a fancy app
@@ -149,7 +150,7 @@ fn main() {
         std::thread::spawn(move || enumerate_all_files(&options, &file_sink, &shared))
     };
 
-    let worker_thread_count = options.jobs.unwrap_or_else(|| num_cpus::get());
+    let worker_thread_count = options.jobs.unwrap_or_else(num_cpus::get);
     let worker_threads: Vec<_> = (0..worker_thread_count)
         .map(|_| create_worker_thread(&file_source, &result_sink, &shared))
         .collect();

--- a/bve-corpus/src/main.rs
+++ b/bve-corpus/src/main.rs
@@ -149,8 +149,7 @@ fn main() {
         std::thread::spawn(move || enumerate_all_files(&options, &file_sink, &shared))
     };
 
-    let thread_count = num_cpus::get();
-    let worker_thread_count = thread_count.saturating_sub(1).max(1);
+    let worker_thread_count = options.jobs.unwrap_or_else(|| num_cpus::get());
     let worker_threads: Vec<_> = (0..worker_thread_count)
         .map(|_| create_worker_thread(&file_source, &result_sink, &shared))
         .collect();

--- a/bve-corpus/src/options.rs
+++ b/bve-corpus/src/options.rs
@@ -10,4 +10,7 @@ pub struct Options {
     /// Location of result file
     #[structopt(short, long)]
     pub output: Option<PathBuf>,
+    /// Job Count
+    #[structopt(short, long)]
+    pub jobs: Option<usize>,
 }

--- a/bve-derive/src/lib.rs
+++ b/bve-derive/src/lib.rs
@@ -43,6 +43,8 @@
 #![allow(clippy::too_many_lines)]
 #![allow(clippy::unreachable)]
 #![allow(clippy::wildcard_enum_match_arm)]
+// CLion is having a fit about panic not existing
+#![feature(core_panic)]
 
 extern crate proc_macro;
 

--- a/bve-derive/src/lib.rs
+++ b/bve-derive/src/lib.rs
@@ -35,6 +35,7 @@
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(clippy::missing_inline_in_public_items)]
 #![allow(clippy::module_name_repetitions)]
+#![allow(clippy::non_ascii_literal)]
 #![allow(clippy::option_expect_used)]
 #![allow(clippy::panic)]
 #![allow(clippy::result_expect_used)]

--- a/bve-native/src/lib.rs
+++ b/bve-native/src/lib.rs
@@ -75,6 +75,7 @@
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(clippy::missing_inline_in_public_items)]
 #![allow(clippy::module_name_repetitions)]
+#![allow(clippy::non_ascii_literal)]
 #![allow(clippy::option_expect_used)]
 #![allow(clippy::panic)]
 #![allow(clippy::result_expect_used)]

--- a/bve/Cargo.toml
+++ b/bve/Cargo.toml
@@ -21,6 +21,7 @@ csv = { version = "1.1" }
 encoding_rs = "0.8.22"
 indexmap = "1.2"
 itertools = "0.8"
+num-traits = "0.2.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_plain = "0.3"
 smallvec = { version = "1", features = ["serde"] }

--- a/bve/src/filesystem/utf8.rs
+++ b/bve/src/filesystem/utf8.rs
@@ -11,16 +11,39 @@ use std::path::Path;
 pub fn read_convert_utf8(filename: impl AsRef<Path>) -> Result<String> {
     let bytes = read(filename)?;
 
-    let mut detector = EncodingDetector::new();
-    let ascii_only = !detector.feed(&bytes, true);
+    convert_to_utf8(bytes)
+}
 
-    if ascii_only {
-        Ok(String::from_utf8(bytes).expect("Only ascii characters detected, but utf8 validation failed"))
+fn convert_to_utf8(bytes: Vec<u8>) -> Result<String> {
+    // Byte order marks are not properly dealt with in chardetng, detect them here, encoding_rs will remove them
+    let encoding = if bytes.len() >= 2 && bytes[0..2] == [0xFF, 0xFE] {
+        encoding_rs::UTF_16LE
+    } else if bytes.len() >= 2 && bytes[0..2] == [0xFE, 0xFF] {
+        encoding_rs::UTF_16BE
+    } else if bytes.len() >= 3 && bytes[0..3] == [0xEF, 0xBB, 0xEF] {
+        encoding_rs::UTF_8
     } else {
-        let encoding = detector.guess(None, true);
+        let mut detector = EncodingDetector::new();
+        let ascii_only = !detector.feed(&bytes, true);
+        if ascii_only {
+            return Ok(String::from_utf8(bytes).expect("Only ascii characters detected, but utf8 validation failed"));
+        }
+        detector.guess(None, true)
+    };
 
-        let (result, ..) = encoding.decode(&bytes);
+    println!("{}", encoding.name());
 
-        Ok(result.to_string())
+    let (result, ..) = encoding.decode_with_bom_removal(&bytes);
+
+    Ok(result.to_string())
+}
+
+#[cfg(test)]
+mod test {
+    use super::convert_to_utf8;
+
+    #[test]
+    fn bom_removal() {
+        assert_eq!(convert_to_utf8(vec![0xFF, 0xFE]).unwrap(), "");
     }
 }

--- a/bve/src/filesystem/utf8.rs
+++ b/bve/src/filesystem/utf8.rs
@@ -31,8 +31,6 @@ fn convert_to_utf8(bytes: Vec<u8>) -> String {
         detector.guess(None, true)
     };
 
-    println!("{}", encoding.name());
-
     let (result, ..) = encoding.decode_with_bom_removal(&bytes);
 
     result.to_string()

--- a/bve/src/filesystem/utf8.rs
+++ b/bve/src/filesystem/utf8.rs
@@ -20,7 +20,7 @@ fn convert_to_utf8(bytes: Vec<u8>) -> Result<String> {
         encoding_rs::UTF_16LE
     } else if bytes.len() >= 2 && bytes[0..2] == [0xFE, 0xFF] {
         encoding_rs::UTF_16BE
-    } else if bytes.len() >= 3 && bytes[0..3] == [0xEF, 0xBB, 0xEF] {
+    } else if bytes.len() >= 3 && bytes[0..3] == [0xEF, 0xBB, 0xBF] {
         encoding_rs::UTF_8
     } else {
         let mut detector = EncodingDetector::new();
@@ -45,5 +45,20 @@ mod test {
     #[test]
     fn bom_removal() {
         assert_eq!(convert_to_utf8(vec![0xFF, 0xFE]).unwrap(), "");
+        assert_eq!(convert_to_utf8(vec![0xFE, 0xFF]).unwrap(), "");
+        assert_eq!(convert_to_utf8(vec![0xEF, 0xBB, 0xBF]).unwrap(), "");
+    }
+
+    #[test]
+    fn shift_jis() {
+        // I'm sorry if this is not "hello how are you", blame google
+        assert_eq!(
+            convert_to_utf8(
+                b"\x82\xb1\x82\xf1\x82\xc9\x82\xbf\x82\xcd\x81\x41\x8c\xb3\x8b\x43\x82\xc5\x82\xb7\x82\xa9\x81\x48"
+                    .to_vec()
+            )
+            .unwrap(),
+            "こんにちは、元気ですか？"
+        );
     }
 }

--- a/bve/src/filesystem/utf8.rs
+++ b/bve/src/filesystem/utf8.rs
@@ -11,10 +11,10 @@ use std::path::Path;
 pub fn read_convert_utf8(filename: impl AsRef<Path>) -> Result<String> {
     let bytes = read(filename)?;
 
-    convert_to_utf8(bytes)
+    Ok(convert_to_utf8(bytes))
 }
 
-fn convert_to_utf8(bytes: Vec<u8>) -> Result<String> {
+fn convert_to_utf8(bytes: Vec<u8>) -> String {
     // Byte order marks are not properly dealt with in chardetng, detect them here, encoding_rs will remove them
     let encoding = if bytes.len() >= 2 && bytes[0..2] == [0xFF, 0xFE] {
         encoding_rs::UTF_16LE
@@ -26,7 +26,7 @@ fn convert_to_utf8(bytes: Vec<u8>) -> Result<String> {
         let mut detector = EncodingDetector::new();
         let ascii_only = !detector.feed(&bytes, true);
         if ascii_only {
-            return Ok(String::from_utf8(bytes).expect("Only ascii characters detected, but utf8 validation failed"));
+            return String::from_utf8(bytes).expect("Only ascii characters detected, but utf8 validation failed");
         }
         detector.guess(None, true)
     };
@@ -35,7 +35,7 @@ fn convert_to_utf8(bytes: Vec<u8>) -> Result<String> {
 
     let (result, ..) = encoding.decode_with_bom_removal(&bytes);
 
-    Ok(result.to_string())
+    result.to_string()
 }
 
 #[cfg(test)]
@@ -44,9 +44,9 @@ mod test {
 
     #[test]
     fn bom_removal() {
-        assert_eq!(convert_to_utf8(vec![0xFF, 0xFE]).unwrap(), "");
-        assert_eq!(convert_to_utf8(vec![0xFE, 0xFF]).unwrap(), "");
-        assert_eq!(convert_to_utf8(vec![0xEF, 0xBB, 0xBF]).unwrap(), "");
+        assert_eq!(convert_to_utf8(vec![0xFF, 0xFE]), "");
+        assert_eq!(convert_to_utf8(vec![0xFE, 0xFF]), "");
+        assert_eq!(convert_to_utf8(vec![0xEF, 0xBB, 0xBF]), "");
     }
 
     #[test]
@@ -56,8 +56,7 @@ mod test {
             convert_to_utf8(
                 b"\x82\xb1\x82\xf1\x82\xc9\x82\xbf\x82\xcd\x81\x41\x8c\xb3\x8b\x43\x82\xc5\x82\xb7\x82\xa9\x81\x48"
                     .to_vec()
-            )
-            .unwrap(),
+            ),
             "こんにちは、元気ですか？"
         );
     }

--- a/bve/src/lib.rs
+++ b/bve/src/lib.rs
@@ -34,6 +34,7 @@
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(clippy::missing_inline_in_public_items)]
 #![allow(clippy::module_name_repetitions)]
+#![allow(clippy::non_ascii_literal)]
 #![allow(clippy::option_expect_used)]
 #![allow(clippy::panic)]
 #![allow(clippy::result_expect_used)]

--- a/bve/src/parse/mesh/instructions/creation.rs
+++ b/bve/src/parse/mesh/instructions/creation.rs
@@ -183,7 +183,7 @@ pub fn create_instructions(input: &str, file_type: FileType) -> InstructionList 
                             v
                         } else {
                             // If only whitespace, this is an instance a line with just commmas `,,,,,`, ignore it
-                            if !name.chars().all(|c: char| c.is_whitespace()) {
+                            if !name.chars().all(char::is_whitespace) {
                                 instructions.errors.push(MeshError {
                                     location: span,
                                     kind: MeshErrorKind::UnknownInstruction { name: name.to_owned() },

--- a/bve/src/parse/mesh/instructions/creation.rs
+++ b/bve/src/parse/mesh/instructions/creation.rs
@@ -182,10 +182,13 @@ pub fn create_instructions(input: &str, file_type: FileType) -> InstructionList 
                         if let Ok(v) = serde_plain::from_str(name) {
                             v
                         } else {
-                            instructions.errors.push(MeshError {
-                                location: span,
-                                kind: MeshErrorKind::UnknownInstruction { name: name.to_owned() },
-                            });
+                            // If only whitespace, this is an instance a line with just commmas `,,,,,`, ignore it
+                            if !name.chars().all(|c: char| c.is_whitespace()) {
+                                instructions.errors.push(MeshError {
+                                    location: span,
+                                    kind: MeshErrorKind::UnknownInstruction { name: name.to_owned() },
+                                });
+                            }
                             continue 'l;
                         }
                     }

--- a/bve/src/parse/mesh/instructions/mod.rs
+++ b/bve/src/parse/mesh/instructions/mod.rs
@@ -134,15 +134,20 @@ pub struct AddFace {
 /// Cannot be executed, must be postprocessing away to [`AddVertex`] and [`AddFace`] commands
 #[bve_derive::serde_proxy]
 pub struct Cube {
+    #[default("util::some_one_f32")]
     pub half_dim: Vector3<f32>,
 }
 
 /// Cannot be executed, must be preprocessed away to [`AddVertex`] and [`AddFace`] commands
 #[bve_derive::serde_proxy]
 pub struct Cylinder {
+    #[default("util::some_eight_u32")]
     pub sides: u32,
+    #[default("util::some_one_f32")]
     pub upper_radius: f32,
+    #[default("util::some_one_f32")]
     pub lower_radius: f32,
+    #[default("util::some_one_f32")]
     pub height: f32,
 }
 

--- a/bve/src/parse/mesh/instructions/mod.rs
+++ b/bve/src/parse/mesh/instructions/mod.rs
@@ -245,7 +245,9 @@ pub struct SetDecalTransparentColor {
 /// Cannot be executed, must be preprocessed away into the corresponding [`AddVertex`] command
 #[bve_derive::serde_proxy]
 pub struct SetTextureCoordinates {
+    #[default("util::some_zero_usize")]
     pub index: usize,
+    #[default("util::some_zero_f32")]
     pub coords: Vector2<f32>,
 }
 

--- a/bve/src/parse/mesh/instructions/tests/instruction_creation.rs
+++ b/bve/src/parse/mesh/instructions/tests/instruction_creation.rs
@@ -230,19 +230,23 @@ fn add_face2() {
 
 #[test]
 fn cube() {
-    instruction_assert!(
+    instruction_assert_default!(
         "Cube",
         "Cube",
         "1, 2, 3",
         InstructionData::Cube(Cube {
             half_dim: Vector3::new(1.0, 2.0, 3.0)
+        }),
+        ",,",
+        InstructionData::Cube(Cube {
+            half_dim: Vector3::new(1.0, 1.0, 1.0)
         })
     );
 }
 
 #[test]
 fn cylinder() {
-    instruction_assert!(
+    instruction_assert_default!(
         "Cylinder",
         "Cylinder",
         "1, 2, 3, 4",
@@ -251,6 +255,13 @@ fn cylinder() {
             upper_radius: 2.0,
             lower_radius: 3.0,
             height: 4.0,
+        }),
+        ",,,",
+        InstructionData::Cylinder(Cylinder {
+            sides: 8,
+            upper_radius: 1.0,
+            lower_radius: 1.0,
+            height: 1.0,
         })
     );
 }

--- a/bve/src/parse/mesh/instructions/tests/instruction_creation.rs
+++ b/bve/src/parse/mesh/instructions/tests/instruction_creation.rs
@@ -79,6 +79,11 @@ fn empty_line() {
 }
 
 #[test]
+fn empty_line_with_commas() {
+    no_instruction_assert_no_errors!(",,,,,,", ",,,,,,,", "");
+}
+
+#[test]
 fn no_arguments() {
     instruction_assert!(
         "Vertex",

--- a/bve/src/parse/mesh/instructions/tests/instruction_creation.rs
+++ b/bve/src/parse/mesh/instructions/tests/instruction_creation.rs
@@ -107,6 +107,32 @@ fn too_many_arguments() {
 }
 
 #[test]
+fn too_many_arguments_end_vector() {
+    instruction_assert!(
+        "Face",
+        "AddFace",
+        "0, 1, 2, 3,",
+        InstructionData::AddFace(AddFace {
+            indexes: vec![0, 1, 2, 3],
+            sides: Sides::One,
+        })
+    );
+}
+
+#[test]
+fn too_many_arguments_middle_vector() {
+    instruction_assert!(
+        "Face",
+        "AddFace",
+        "0, 1, 2,,,,,,,,3",
+        InstructionData::AddFace(AddFace {
+            indexes: vec![0, 1, 2, 3],
+            sides: Sides::One,
+        })
+    );
+}
+
+#[test]
 fn beginning_of_line_comment() {
     no_instruction_assert_no_errors!(";", ";", "");
 }

--- a/bve/src/parse/mesh/instructions/tests/instruction_creation.rs
+++ b/bve/src/parse/mesh/instructions/tests/instruction_creation.rs
@@ -586,13 +586,18 @@ fn instruction_assert_default() {
 
 #[test]
 fn texture_coordinates() {
-    instruction_assert!(
+    instruction_assert_default!(
         "Coordinates",
         "SetTextureCoordinates",
         "1, 2, 3",
         InstructionData::SetTextureCoordinates(SetTextureCoordinates {
             index: 1,
             coords: Vector2::new(2.0, 3.0),
+        }),
+        ",,",
+        InstructionData::SetTextureCoordinates(SetTextureCoordinates {
+            index: 0,
+            coords: Vector2::new(0.0, 0.0),
         })
     );
 }

--- a/bve/src/parse/util/loose_numbers.rs
+++ b/bve/src/parse/util/loose_numbers.rs
@@ -6,6 +6,7 @@ use std::fmt::Formatter;
 use std::str::FromStr;
 
 #[derive(Debug, Copy, Clone, PartialOrd, PartialEq, Default)]
+#[repr(transparent)]
 pub struct LooseNumber<T>(pub T);
 
 impl<'de, T> Deserialize<'de> for LooseNumber<T>
@@ -16,25 +17,25 @@ where
     where
         D: Deserializer<'de>,
     {
-        deserializer.deserialize_str(LooseFloatVisitor { pd: PhantomData::<T> })
+        deserializer.deserialize_str(LooseNumberVisitor { pd: PhantomData::<T> })
     }
 }
 
-struct LooseFloatVisitor<T>
+struct LooseNumberVisitor<T>
 where
     T: FromStr,
 {
     pd: PhantomData<T>,
 }
 
-impl<'de, T> Visitor<'de> for LooseFloatVisitor<T>
+impl<'de, T> Visitor<'de> for LooseNumberVisitor<T>
 where
     T: FromStr,
 {
     type Value = LooseNumber<T>;
 
     fn expecting<'a>(&self, formatter: &mut Formatter<'a>) -> fmt::Result {
-        write!(formatter, "Expected loose float.")
+        write!(formatter, "Expected loose number.")
     }
 
     fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
@@ -50,7 +51,10 @@ where
                 Err(_) => filtered.pop(),
             };
         }
-        Err(serde::de::Error::custom(format!("Error parsing the loose float {}", v)))
+        Err(serde::de::Error::custom(format!(
+            "Error parsing the loose number {}",
+            v
+        )))
     }
 }
 

--- a/bve/src/parse/util/mod.rs
+++ b/bve/src/parse/util/mod.rs
@@ -30,6 +30,10 @@ pub(in crate::parse) const fn some_eight_u32() -> Option<LooseNumber<u32>> {
     Some(LooseNumber(8))
 }
 
+pub(in crate::parse) const fn some_zero_usize() -> Option<LooseNumber<usize>> {
+    Some(LooseNumber(0))
+}
+
 pub(in crate::parse) const fn some_zero_f32() -> Option<LooseNumber<f32>> {
     Some(LooseNumber(0.0))
 }

--- a/bve/src/parse/util/mod.rs
+++ b/bve/src/parse/util/mod.rs
@@ -26,6 +26,10 @@ pub(in crate::parse) const fn some_zero_u16() -> Option<LooseNumber<u16>> {
     Some(LooseNumber(0))
 }
 
+pub(in crate::parse) const fn some_eight_u32() -> Option<LooseNumber<u32>> {
+    Some(LooseNumber(8))
+}
+
 pub(in crate::parse) const fn some_zero_f32() -> Option<LooseNumber<f32>> {
     Some(LooseNumber(0.0))
 }


### PR DESCRIPTION
This fixes a couple of main issues exposed by the corpus tester.

- Many instructions did not have defaults per the spec, but irl had defaults that needed to be reproduced.
- `.` is a valid number
- utf-8 and utf-16 with a BOM was not detected correctly, leading to tons of errors

The next thing I need to do is fix up logging, as I currently basically have no logging anywhere!