### PR TITLE
Fix Underflow in Mesh Instruction Post Processing

### DIFF
--- a/bve-corpus/src/main.rs
+++ b/bve-corpus/src/main.rs
@@ -133,7 +133,7 @@ fn main() {
 
     let options: Options = Options::from_args();
 
-    let _guard = set_global_logger(std::io::stderr(), SerializationMethod::JsonPretty);
+    let _guard = set_global_logger(std::io::sink(), SerializationMethod::JsonPretty);
 
     run_with_global_logger(move || program_main(options));
 }

--- a/bve/src/parse/mesh/instructions/post_processing.rs
+++ b/bve/src/parse/mesh/instructions/post_processing.rs
@@ -129,7 +129,8 @@ fn process_compound(mesh: &[Instruction]) -> Vec<Instruction> {
                 // Faces
                 let vi = vertex_index;
 
-                let split = (n - 1).max(0) as usize;
+                // logically (n - 1).max(0) but that caused underflow
+                let split = (n.max(1) - 1) as usize;
                 for i in 0..split {
                     result.push(create_face(
                         instruction,

--- a/bve/src/parse/mesh/instructions/post_processing.rs
+++ b/bve/src/parse/mesh/instructions/post_processing.rs
@@ -129,8 +129,7 @@ fn process_compound(mesh: &[Instruction]) -> Vec<Instruction> {
                 // Faces
                 let vi = vertex_index;
 
-                // logically (n - 1).max(0) but that caused underflow
-                let split = (n.max(1) - 1) as usize;
+                let split = n.saturating_sub(1) as usize;
                 for i in 0..split {
                     result.push(create_face(
                         instruction,


### PR DESCRIPTION
I had underflow when trying to do `(n - 1).max(0)` which if n is zero underflows.