### PR TITLE
Add Mesh Warnings 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -192,7 +192,6 @@ dependencies = [
  "indicatif",
  "itertools",
  "libc",
- "matches",
  "num_cpus",
  "serde",
  "serde_json",
@@ -691,12 +690,6 @@ checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matches"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ffc5c5338469d4d3ea17d269fa8ea3512ad247247c30bd2df69e68309ed0a08"
 
 [[package]]
 name = "memchr"

--- a/bve-corpus/Cargo.toml
+++ b/bve-corpus/Cargo.toml
@@ -22,7 +22,6 @@ crossbeam = "0.7.3"
 indicatif = "0.14.0"
 itertools = "0.8.2"
 libc = "0.2.66"
-matches = "0.1.8"
 num_cpus = "1.12.0"
 serde = { version = "1.0.104", features = ["derive"] }
 serde_json = "1.0.45"

--- a/bve-corpus/src/bin/bve-parser-run.rs
+++ b/bve-corpus/src/bin/bve-parser-run.rs
@@ -1,5 +1,5 @@
 use bve::filesystem::read_convert_utf8;
-use bve::parse::mesh::{mesh_from_str, MeshErrorKind};
+use bve::parse::mesh::mesh_from_str;
 use clap::arg_enum;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
@@ -36,16 +36,16 @@ fn parse_mesh_b3d_csv(file: impl AsRef<Path>, errors: bool, b3d: bool) {
     };
 
     let start = Instant::now();
-    let mut parsed = mesh_from_str(&contents, file_type);
+    let parsed = mesh_from_str(&contents, file_type);
     let duration = Instant::now() - start;
 
     println!("Duration: {:.4}", duration.as_secs_f32());
 
-    parsed
-        .errors
-        .retain(|v| !matches!(v.kind, MeshErrorKind::UselessInstruction{..}));
-
     if errors {
+        println!("Warnings:");
+        for e in &parsed.warnings {
+            println!("\t{} {:?}", e.location.line.map(|v| v as i64).unwrap_or(-1), e.kind)
+        }
         println!("Errors:");
         for e in &parsed.errors {
             println!("\t{} {:?}", e.location.line.map(|v| v as i64).unwrap_or(-1), e.kind)

--- a/bve-corpus/src/worker/mod.rs
+++ b/bve-corpus/src/worker/mod.rs
@@ -61,7 +61,7 @@ fn processing_loop(
         USE_DEFAULT_PANIC_HANLDER.with(|v| *v.borrow_mut() = false);
         let panicked = std::panic::catch_unwind(|| match file.kind {
             FileKind::ModelCsv => {
-                let ParsedStaticObject { mut errors, .. } = mesh_from_str(
+                let ParsedStaticObject { errors, .. } = mesh_from_str(
                     &match read_convert_utf8(&file.path) {
                         Ok(s) => s,
                         Err(err) => {
@@ -71,8 +71,6 @@ fn processing_loop(
                     },
                     FileType::CSV,
                 );
-
-                errors.retain(|v| !matches!(v.kind, MeshErrorKind::UselessInstruction{..}));
 
                 ParseResult::Errors {
                     count: errors.len() as u64,

--- a/bve-native/src/parse/mesh.rs
+++ b/bve-native/src/parse/mesh.rs
@@ -282,7 +282,7 @@ impl Into<mesh::MeshErrorKind> for Mesh_Error_Kind {
     }
 }
 
-/// C safe wrapper for [`MeshError`](bve::parse::mesh::MeshWarning).
+/// C safe wrapper for [`MeshWarning`](bve::parse::mesh::MeshWarning).
 ///
 /// # Safety
 ///
@@ -311,7 +311,7 @@ impl Into<mesh::MeshWarning> for Mesh_Warning {
     }
 }
 
-/// C safe wrapper for [`MeshErrorKind`](bve::parse::mesh::MeshWarningKind).
+/// C safe wrapper for [`MeshWarningKind`](bve::parse::mesh::MeshWarningKind).
 ///
 /// # Safety
 ///

--- a/bve/src/parse/mesh/errors.rs
+++ b/bve/src/parse/mesh/errors.rs
@@ -1,5 +1,21 @@
 use crate::parse::Span;
 
+/// A warning in the parsing or evaluation of a mesh.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MeshWarning {
+    /// Info about the exact error.
+    pub kind: MeshWarningKind,
+    /// Location of the error within the file.
+    pub location: Span,
+}
+
+/// Enum representing various types of warnings encountered when parsing meshes
+#[derive(Debug, Clone, PartialEq)]
+pub enum MeshWarningKind {
+    /// Instruction no longer does anything anymore
+    UselessInstruction { name: String },
+}
+
 /// A single error in the parsing or evaluation of a mesh.
 #[derive(Debug, Clone, PartialEq)]
 pub struct MeshError {
@@ -19,8 +35,6 @@ pub enum MeshErrorKind {
     },
     /// Index provided to vertex-specific command is out of bounds.
     OutOfBounds { idx: usize },
-    /// Instruction no longer does anything anymore
-    UselessInstruction { name: String },
     /// Unrecognized instruction
     UnknownInstruction {
         /// Instruction that is not recognized

--- a/bve/src/parse/mesh/instructions/creation.rs
+++ b/bve/src/parse/mesh/instructions/creation.rs
@@ -23,24 +23,24 @@ pub(in crate::parse::mesh::instructions) fn b3d_to_csv_syntax(input: &str) -> St
     p
 }
 
-enum DeserializeInstruction {
+enum DeserializeInstructionError {
     MeshError(MeshError),
     MeshWarning(MeshWarning),
 }
 
-impl From<MeshError> for DeserializeInstruction {
+impl From<MeshError> for DeserializeInstructionError {
     fn from(e: MeshError) -> Self {
         Self::MeshError(e)
     }
 }
 
-impl From<MeshWarning> for DeserializeInstruction {
+impl From<MeshWarning> for DeserializeInstructionError {
     fn from(e: MeshWarning) -> Self {
         Self::MeshWarning(e)
     }
 }
 
-impl From<csv::Error> for DeserializeInstruction {
+impl From<csv::Error> for DeserializeInstructionError {
     fn from(e: csv::Error) -> Self {
         e.into()
     }
@@ -50,7 +50,7 @@ fn deserialize_instruction(
     inst_type: InstructionType,
     record: &StringRecord,
     span: Span,
-) -> Result<Instruction, DeserializeInstruction> {
+) -> Result<Instruction, DeserializeInstructionError> {
     let data = match inst_type {
         InstructionType::CreateMeshBuilder => InstructionData::CreateMeshBuilder(CreateMeshBuilder),
         InstructionType::AddVertex => {
@@ -236,11 +236,11 @@ pub fn create_instructions(input: &str, file_type: FileType) -> InstructionList 
 
                 match inst {
                     Ok(i) => instructions.instructions.push(i),
-                    Err(DeserializeInstruction::MeshWarning(mut e)) => {
+                    Err(DeserializeInstructionError::MeshWarning(mut e)) => {
                         e.location = span;
                         instructions.warnings.push(e)
                     }
-                    Err(DeserializeInstruction::MeshError(mut e)) => {
+                    Err(DeserializeInstructionError::MeshError(mut e)) => {
                         e.location = span;
                         instructions.errors.push(e)
                     }

--- a/bve/src/parse/mesh/instructions/creation.rs
+++ b/bve/src/parse/mesh/instructions/creation.rs
@@ -1,5 +1,5 @@
 use crate::parse::mesh::instructions::*;
-use crate::parse::mesh::{FileType, MeshError, MeshErrorKind};
+use crate::parse::mesh::{FileType, MeshError, MeshErrorKind, MeshWarning, MeshWarningKind};
 use crate::parse::util::strip_comments;
 use crate::parse::Span;
 use csv::{ReaderBuilder, StringRecord, Trim};
@@ -23,11 +23,34 @@ pub(in crate::parse::mesh::instructions) fn b3d_to_csv_syntax(input: &str) -> St
     p
 }
 
+enum DeserializeInstruction {
+    MeshError(MeshError),
+    MeshWarning(MeshWarning),
+}
+
+impl From<MeshError> for DeserializeInstruction {
+    fn from(e: MeshError) -> Self {
+        Self::MeshError(e)
+    }
+}
+
+impl From<MeshWarning> for DeserializeInstruction {
+    fn from(e: MeshWarning) -> Self {
+        Self::MeshWarning(e)
+    }
+}
+
+impl From<csv::Error> for DeserializeInstruction {
+    fn from(e: csv::Error) -> Self {
+        e.into()
+    }
+}
+
 fn deserialize_instruction(
     inst_type: InstructionType,
     record: &StringRecord,
     span: Span,
-) -> Result<Instruction, MeshError> {
+) -> Result<Instruction, DeserializeInstruction> {
     let data = match inst_type {
         InstructionType::CreateMeshBuilder => InstructionData::CreateMeshBuilder(CreateMeshBuilder),
         InstructionType::AddVertex => {
@@ -54,21 +77,23 @@ fn deserialize_instruction(
         }
         InstructionType::GenerateNormals => {
             tracing::info!(?inst_type, ?record, line = ?span.line, "Useless instruction");
-            return Err(MeshError {
-                kind: MeshErrorKind::UselessInstruction {
+            return Err(MeshWarning {
+                kind: MeshWarningKind::UselessInstruction {
                     name: String::from("GenerateNormals"),
                 },
                 location: span,
-            });
+            }
+            .into());
         }
         InstructionType::Texture => {
             tracing::info!(?inst_type, ?record, line = ?span.line, "Useless instruction");
-            return Err(MeshError {
-                kind: MeshErrorKind::UselessInstruction {
+            return Err(MeshWarning {
+                kind: MeshWarningKind::UselessInstruction {
                     name: String::from("[texture]"),
                 },
                 location: span,
-            });
+            }
+            .into());
         }
         InstructionType::Translate => {
             let mut parsed: Translate = record.deserialize(None)?;
@@ -211,7 +236,11 @@ pub fn create_instructions(input: &str, file_type: FileType) -> InstructionList 
 
                 match inst {
                     Ok(i) => instructions.instructions.push(i),
-                    Err(mut e) => {
+                    Err(DeserializeInstruction::MeshWarning(mut e)) => {
+                        e.location = span;
+                        instructions.warnings.push(e)
+                    }
+                    Err(DeserializeInstruction::MeshError(mut e)) => {
                         e.location = span;
                         instructions.errors.push(e)
                     }

--- a/bve/src/parse/mesh/instructions/execution.rs
+++ b/bve/src/parse/mesh/instructions/execution.rs
@@ -322,6 +322,7 @@ pub fn generate_meshes(instructions: InstructionList) -> ParsedStaticObject {
     }
     run_create_mesh_builder(&mut mbc);
     tracing::debug!(errors = instructions.errors.len(), "Generated mesh");
+    mbc.parsed.warnings = instructions.warnings;
     mbc.parsed.errors = instructions.errors;
     mbc.parsed
 }

--- a/bve/src/parse/mesh/instructions/mod.rs
+++ b/bve/src/parse/mesh/instructions/mod.rs
@@ -14,7 +14,7 @@
 //! Makes heavy use of [`bve-derive::serde_proxy`](../../../../bve_derive/attr.serde_proxy.html) and
 //! [`bve-derive::serde_vector_proxy`](../../../../bve_derive/attr.serde_vector_proxy.html)
 
-use crate::parse::mesh::{BlendMode, GlowAttenuationMode, MeshError};
+use crate::parse::mesh::{BlendMode, GlowAttenuationMode, MeshError, MeshWarning};
 use crate::parse::{util, Span};
 use crate::{ColorU8RGB, ColorU8RGBA};
 use cgmath::{Vector2, Vector3};
@@ -32,6 +32,7 @@ mod tests;
 #[derive(Debug, Clone, PartialEq)]
 pub struct InstructionList {
     pub instructions: Vec<Instruction>,
+    pub warnings: Vec<MeshWarning>,
     pub errors: Vec<MeshError>,
 }
 
@@ -39,6 +40,7 @@ impl InstructionList {
     const fn new() -> Self {
         Self {
             instructions: Vec::new(),
+            warnings: Vec::new(),
             errors: Vec::new(),
         }
     }

--- a/bve/src/parse/mesh/instructions/tests/instruction_creation.rs
+++ b/bve/src/parse/mesh/instructions/tests/instruction_creation.rs
@@ -7,11 +7,17 @@ use cgmath::{Vector2, Vector3};
 macro_rules! no_instruction_assert_no_errors {
     ( $inputB3D:literal, $inputCSV:literal, $args:literal ) => {
         let result_a = create_instructions(concat!($inputB3D, " ", $args).into(), FileType::B3D);
+        if !result_a.warnings.is_empty() {
+            panic!("WARNINGS!! {:#?}", result_a)
+        }
         if !result_a.errors.is_empty() {
             panic!("ERRORS!! {:#?}", result_a)
         }
         assert_eq!(result_a.instructions.len(), 0);
         let result_b = create_instructions(concat!($inputCSV, ",", $args).into(), FileType::CSV);
+        if !result_b.warnings.is_empty() {
+            panic!("WARNINGS!! {:#?}", result_b)
+        }
         if !result_b.errors.is_empty() {
             panic!("ERRORS!! {:#?}", result_b)
         }
@@ -19,9 +25,34 @@ macro_rules! no_instruction_assert_no_errors {
     };
 }
 
+macro_rules! no_instruction_assert_warnings {
+    ( $inputB3D:literal, $inputCSV:literal, $args:literal ) => {
+        let result_a = create_instructions(concat!($inputB3D, " ", $args).into(), FileType::B3D);
+        if result_a.warnings.is_empty() {
+            panic!("Missing Warnings: {:#?}", result_a)
+        }
+        if !result_a.errors.is_empty() {
+            panic!("ERRORS!! {:#?}", result_a)
+        }
+        assert_eq!(result_a.instructions.len(), 0);
+        let result_b = create_instructions(concat!($inputCSV, ",", $args).into(), FileType::CSV);
+        if result_b.warnings.is_empty() {
+            panic!("Missing Warnings: {:#?}", result_b)
+        }
+        if !result_b.errors.is_empty() {
+            panic!("ERRORS!! {:#?}", result_b)
+        }
+        assert_eq!(result_b.instructions.len(), 0);
+    };
+}
+
+#[allow(unused_macros)]
 macro_rules! no_instruction_assert_errors {
     ( $inputB3D:literal, $inputCSV:literal, $args:literal ) => {
         let result_a = create_instructions(concat!($inputB3D, " ", $args).into(), FileType::B3D);
+        if !result_a.warnings.is_empty() {
+            panic!("WARNINGS!! {:#?}", result_a)
+        }
         if result_a.errors.is_empty() {
             panic!("Missing Errors: {:#?}", result_a)
         }
@@ -30,6 +61,9 @@ macro_rules! no_instruction_assert_errors {
         if result_b.errors.is_empty() {
             panic!("Missing Errors: {:#?}", result_b)
         }
+        if !result_b.warnings.is_empty() {
+            panic!("WARNINGS!! {:#?}", result_b)
+        }
         assert_eq!(result_b.instructions.len(), 0);
     };
 }
@@ -37,6 +71,9 @@ macro_rules! no_instruction_assert_errors {
 macro_rules! instruction_assert {
     ( $inputB3D:literal, $inputCSV:literal, $args:literal, $data:expr ) => {
         let result_a = create_instructions(concat!($inputB3D, " ", $args).into(), FileType::B3D);
+        if !result_a.warnings.is_empty() {
+            panic!("WARNINGS!! {:#?}", result_a)
+        }
         if !result_a.errors.is_empty() {
             panic!("ERRORS!! {:#?}", result_a)
         }
@@ -48,6 +85,9 @@ macro_rules! instruction_assert {
             }
         );
         let result_b = create_instructions(concat!($inputCSV, ",", $args).into(), FileType::CSV);
+        if !result_b.warnings.is_empty() {
+            panic!("WARNINGS!! {:#?}", result_b)
+        }
         if !result_b.errors.is_empty() {
             panic!("ERRORS!! {:#?}", result_b)
         }
@@ -284,13 +324,13 @@ fn cylinder() {
 #[bve_derive::bve_test]
 #[test]
 fn generate_normals() {
-    no_instruction_assert_errors!("GenerateNormals", "GenerateNormals", "");
+    no_instruction_assert_warnings!("GenerateNormals", "GenerateNormals", "");
 }
 
 #[bve_derive::bve_test]
 #[test]
 fn texture() {
-    no_instruction_assert_errors!("[texture]", "Texture", "");
+    no_instruction_assert_warnings!("[texture]", "Texture", "");
 }
 
 #[bve_derive::bve_test]

--- a/bve/src/parse/mesh/instructions/tests/instruction_execution.rs
+++ b/bve/src/parse/mesh/instructions/tests/instruction_execution.rs
@@ -18,6 +18,7 @@ macro_rules! generate_instruction_list {
                     line: Some($num)
                 }
             }),+],
+            warnings: vec![],
             errors: vec![],
         }
     };

--- a/bve/src/parse/mesh/instructions/tests/mod.rs
+++ b/bve/src/parse/mesh/instructions/tests/mod.rs
@@ -62,6 +62,7 @@ fn generate_instructions_from_obj(input: &'static str) -> InstructionList {
 
     InstructionList {
         instructions: result,
+        warnings: Vec::default(),
         errors: Vec::default(),
     }
 }

--- a/bve/src/parse/mesh/mod.rs
+++ b/bve/src/parse/mesh/mod.rs
@@ -43,6 +43,8 @@ pub struct ParsedStaticObject {
     pub meshes: Vec<Mesh>,
     /// The set of texture names needed by mesh
     pub textures: TextureSet,
+    /// Warnings when creating the mesh. Does not affect mesh.
+    pub warnings: Vec<MeshWarning>,
     /// Errors when creating the mesh. If there are enough errors, there might not even be any meshes!
     pub errors: Vec<MeshError>,
 }


### PR DESCRIPTION
This PR crates a separate category of mesh warnings to allow things like useless instruction to be ignored.

This PR involved a decent amount of copy paste so it should be pretty thoroughly checked. 