### PR TITLE
Add Function Script Parsing Support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -46,6 +46,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64cf76cb6e2222ed0ea86b2b0ee2f71c96ec6edd5af42e84d59160e91b836ec4"
 
 [[package]]
+name = "arrayvec"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd9fd44efafa8690358b7408d253adf110036b88f55672a933f01d616ad9b1b9"
+dependencies = [
+ "nodrop",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -151,6 +160,7 @@ dependencies = [
  "itertools",
  "lazy_static",
  "maplit",
+ "nom 5.1.0",
  "num-traits",
  "obj",
  "serde",
@@ -295,7 +305,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fce5b5fb86b0c57c20c834c1b412fd09c77c8a59b9473f86272709e78874cd1d"
 dependencies = [
- "nom",
+ "nom 4.2.3",
 ]
 
 [[package]]
@@ -653,6 +663,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
+name = "lexical-core"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14"
+dependencies = [
+ "arrayvec",
+ "cfg-if",
+ "rustc_version",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -736,11 +759,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "nodrop"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
+
+[[package]]
 name = "nom"
 version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 dependencies = [
+ "memchr",
+ "version_check",
+]
+
+[[package]]
+name = "nom"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c433f4d505fe6ce7ff78523d2fa13a0b9f2690e181fc26168bcbe5ccc5d14e07"
+dependencies = [
+ "lexical-core",
  "memchr",
  "version_check",
 ]
@@ -1086,6 +1126,12 @@ checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f3eb36b47e512f8f1c9e3d10c2c1965bc992bd9cdb024fa581e2194501c83d3"
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,6 @@ dependencies = [
  "serde_json",
  "serde_plain",
  "serde_test",
- "smallvec",
  "tracing",
  "tracing-core",
  "tracing-subscriber",
@@ -1123,9 +1122,6 @@ name = "smallvec"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "static_assertions"

--- a/bve-build/src/main.rs
+++ b/bve-build/src/main.rs
@@ -32,6 +32,7 @@
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(clippy::missing_inline_in_public_items)]
 #![allow(clippy::module_name_repetitions)]
+#![allow(clippy::multiple_crate_versions)] // Cargo deny's job
 #![allow(clippy::non_ascii_literal)]
 #![allow(clippy::option_expect_used)]
 #![allow(clippy::panic)]

--- a/bve-corpus/src/main.rs
+++ b/bve-corpus/src/main.rs
@@ -31,6 +31,7 @@
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(clippy::missing_inline_in_public_items)]
 #![allow(clippy::module_name_repetitions)]
+#![allow(clippy::multiple_crate_versions)] // Cargo deny's job
 #![allow(clippy::non_ascii_literal)]
 #![allow(clippy::option_expect_used)]
 #![allow(clippy::panic)]

--- a/bve-corpus/src/main.rs
+++ b/bve-corpus/src/main.rs
@@ -133,7 +133,7 @@ fn main() {
 
     let options: Options = Options::from_args();
 
-    let _guard = set_global_logger(std::io::stderr(), SerializationMethod::JsonPretty);
+    let _guard = set_global_logger(std::io::sink(), SerializationMethod::JsonPretty);
 
     run_with_global_logger(move || program_main(options));
 }

--- a/bve-derive/src/lib.rs
+++ b/bve-derive/src/lib.rs
@@ -35,6 +35,7 @@
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(clippy::missing_inline_in_public_items)]
 #![allow(clippy::module_name_repetitions)]
+#![allow(clippy::multiple_crate_versions)] // Cargo deny's job
 #![allow(clippy::non_ascii_literal)]
 #![allow(clippy::option_expect_used)]
 #![allow(clippy::panic)]

--- a/bve-native/src/lib.rs
+++ b/bve-native/src/lib.rs
@@ -75,6 +75,7 @@
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(clippy::missing_inline_in_public_items)]
 #![allow(clippy::module_name_repetitions)]
+#![allow(clippy::multiple_crate_versions)] // Cargo deny's job
 #![allow(clippy::non_ascii_literal)]
 #![allow(clippy::option_expect_used)]
 #![allow(clippy::panic)]

--- a/bve/Cargo.toml
+++ b/bve/Cargo.toml
@@ -29,7 +29,6 @@ num-traits = "0.2.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.45"
 serde_plain = "0.3"
-smallvec = { version = "1", features = ["serde"] }
 tracing = "0.1.12"
 tracing-core = "0.1.9"
 

--- a/bve/Cargo.toml
+++ b/bve/Cargo.toml
@@ -24,6 +24,7 @@ encoding_rs = "0.8.22"
 indexmap = "1.2"
 itertools = "0.8"
 lazy_static = "1.4.0"
+nom = "5.1.0"
 num-traits = "0.2.11"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.45"

--- a/bve/src/lib.rs
+++ b/bve/src/lib.rs
@@ -33,6 +33,7 @@
 #![allow(clippy::missing_docs_in_private_items)]
 #![allow(clippy::missing_inline_in_public_items)]
 #![allow(clippy::module_name_repetitions)]
+#![allow(clippy::multiple_crate_versions)] // Cargo deny's job
 #![allow(clippy::non_ascii_literal)]
 #![allow(clippy::option_expect_used)]
 #![allow(clippy::panic)]

--- a/bve/src/parse/function_scripts/ir.rs
+++ b/bve/src/parse/function_scripts/ir.rs
@@ -1,0 +1,21 @@
+#[derive(Debug, Clone, PartialEq)]
+pub enum Instruction {
+    Addition,
+    Subtraction,
+    Multiplication,
+    Division,
+    LogicalOr,
+    LogicalAnd,
+    LogicalXor,
+    UnaryLogicalNot,
+    UnaryNegative,
+    Equal,
+    NotEqual,
+    Less,
+    Greater,
+    LessEqual,
+    GreaterEqual,
+    FunctionCall { name: String, arg_count: usize },
+    Variable { name: String },
+    Number { value: f64 },
+}

--- a/bve/src/parse/function_scripts/mod.rs
+++ b/bve/src/parse/function_scripts/mod.rs
@@ -1,0 +1,1 @@
+mod parser;

--- a/bve/src/parse/function_scripts/mod.rs
+++ b/bve/src/parse/function_scripts/mod.rs
@@ -1,1 +1,5 @@
+mod ir;
 mod parser;
+
+pub use ir::*;
+pub use parser::*;

--- a/bve/src/parse/function_scripts/parser.rs
+++ b/bve/src/parse/function_scripts/parser.rs
@@ -122,7 +122,7 @@ fn logical_not(input: &str) -> IResult<&str, Vec<Instruction>> {
 }
 
 fn equal_symbol(input: &str) -> IResult<&str, &str> {
-    w(alt((tag("=="), tag("!="), tag(">"), tag("<"), tag("<="), tag(">="))))(input)
+    w(alt((tag("=="), tag("!="), tag("<="), tag(">="), tag(">"), tag("<"))))(input)
 }
 
 fn equal_expr(input: &str) -> IResult<&str, Vec<Instruction>> {

--- a/bve/src/parse/function_scripts/parser.rs
+++ b/bve/src/parse/function_scripts/parser.rs
@@ -1,0 +1,45 @@
+use nom::branch::alt;
+use nom::bytes::complete::take_while;
+use nom::character::complete::char as char_f;
+use nom::combinator::opt;
+use nom::sequence::delimited;
+use nom::{IResult, InputTakeAtPosition};
+
+/// Takes a parser and wraps it so it delimited with whitespace
+fn w<F, I, O>(func: F) -> impl Fn(I) -> IResult<I, O>
+where
+    I: InputTakeAtPosition<Item = char>,
+    F: Fn(I) -> IResult<I, O>,
+{
+    move |input| {
+        delimited(
+            take_while(char::is_whitespace), //
+            &func,
+            take_while(char::is_whitespace),
+        )(input)
+    }
+}
+
+pub fn parse_function_script(input: &str) -> IResult<&str, ()> {
+    logical_or(input)
+}
+
+fn logical_or(input: &str) -> IResult<&str, ()> {
+    delimited(logical_xor, w(char_f('|')), logical_or)(input).map(|(input, _)| (input, ()))
+}
+
+fn logical_xor(input: &str) -> IResult<&str, ()> {
+    delimited(logical_and, w(char_f('^')), logical_xor)(input).map(|(input, _)| (input, ()))
+}
+
+fn logical_and(input: &str) -> IResult<&str, ()> {
+    delimited(logical_not, w(char_f('^')), logical_xor)(input).map(|(input, _)| (input, ()))
+}
+
+fn logical_not(input: &str) -> IResult<&str, ()> {
+    alt((opt(w(char_f('!'))), equal_expr))(input).map(|(input, _)| (input, ()))
+}
+
+fn equal_expr(input: &str) -> IResult<&str, ()> {}
+
+fn equal_symbol(input: &str) -> IResult<&str, ()> {}

--- a/bve/src/parse/function_scripts/parser.rs
+++ b/bve/src/parse/function_scripts/parser.rs
@@ -1,9 +1,10 @@
 use nom::branch::alt;
-use nom::bytes::complete::take_while;
-use nom::character::complete::char as char_f;
+use nom::bytes::complete::{tag, take_while};
+use nom::character::complete::{char as char_f, one_of};
 use nom::combinator::opt;
-use nom::sequence::delimited;
-use nom::{IResult, InputTakeAtPosition};
+use nom::multi::many0;
+use nom::sequence::{delimited, tuple};
+use nom::{AsChar, IResult, InputTakeAtPosition};
 
 /// Takes a parser and wraps it so it delimited with whitespace
 fn w<F, I, O>(func: F) -> impl Fn(I) -> IResult<I, O>
@@ -20,26 +21,127 @@ where
     }
 }
 
+fn binary<F1, F2, F3, I, O1, O2, O3>(
+    left: F1,
+    middle: F2,
+    right: F3,
+) -> impl FnOnce(I) -> IResult<I, (O1, Option<(O2, O3)>)>
+where
+    I: InputTakeAtPosition<Item = char> + Clone,
+    F1: Fn(I) -> IResult<I, O1>,
+    F2: Fn(I) -> IResult<I, O2>,
+    F3: Fn(I) -> IResult<I, O3>,
+{
+    move |input| tuple((left, opt(tuple((middle, right)))))(input)
+}
+
+fn unary<F1, F2, I, O1, O2>(left: F1, right: F2) -> impl FnOnce(I) -> IResult<I, (Option<O1>, O2)>
+where
+    I: InputTakeAtPosition<Item = char> + Clone,
+    F1: Fn(I) -> IResult<I, O1>,
+    F2: Fn(I) -> IResult<I, O2>,
+{
+    move |input| tuple((opt(w(left)), right))(input)
+}
+
 pub fn parse_function_script(input: &str) -> IResult<&str, ()> {
+    expression(input)
+}
+
+pub fn expression(input: &str) -> IResult<&str, ()> {
     logical_or(input)
 }
 
 fn logical_or(input: &str) -> IResult<&str, ()> {
-    delimited(logical_xor, w(char_f('|')), logical_or)(input).map(|(input, _)| (input, ()))
+    binary(logical_xor, char_f('|'), logical_or)(input).map(|(input, _)| (input, ()))
 }
 
 fn logical_xor(input: &str) -> IResult<&str, ()> {
-    delimited(logical_and, w(char_f('^')), logical_xor)(input).map(|(input, _)| (input, ()))
+    binary(logical_and, char_f('^'), logical_xor)(input).map(|(input, _)| (input, ()))
 }
 
 fn logical_and(input: &str) -> IResult<&str, ()> {
-    delimited(logical_not, w(char_f('^')), logical_xor)(input).map(|(input, _)| (input, ()))
+    binary(logical_not, char_f('^'), logical_xor)(input).map(|(input, _)| (input, ()))
 }
 
 fn logical_not(input: &str) -> IResult<&str, ()> {
-    alt((opt(w(char_f('!'))), equal_expr))(input).map(|(input, _)| (input, ()))
+    unary(char_f('!'), equal_expr)(input).map(|(input, _)| (input, ()))
 }
 
-fn equal_expr(input: &str) -> IResult<&str, ()> {}
+fn equal_symbol(input: &str) -> IResult<&str, &str> {
+    w(alt((tag("=="), tag("!="), tag(">"), tag("<"), tag("<="), tag(">="))))(input)
+}
 
-fn equal_symbol(input: &str) -> IResult<&str, ()> {}
+fn equal_expr(input: &str) -> IResult<&str, ()> {
+    binary(plus_expr, equal_symbol, equal_expr)(input).map(|(input, _)| (input, ()))
+}
+
+fn plus_symbol(input: &str) -> IResult<&str, char> {
+    w(alt((char_f('+'), char_f('-'))))(input)
+}
+
+fn plus_expr(input: &str) -> IResult<&str, ()> {
+    binary(times_expr, plus_symbol, plus_expr)(input).map(|(input, _)| (input, ()))
+}
+
+fn times_expr(input: &str) -> IResult<&str, ()> {
+    binary(divide_expr, char_f('*'), times_expr)(input).map(|(input, _)| (input, ()))
+}
+
+fn divide_expr(input: &str) -> IResult<&str, ()> {
+    binary(unary_minus_expr, char_f('*'), times_expr)(input).map(|(input, _)| (input, ()))
+}
+
+fn unary_minus_expr(input: &str) -> IResult<&str, ()> {
+    unary(char_f('-'), function_expr)(input).map(|(input, _)| (input, ()))
+}
+
+fn function_expr(input: &str) -> IResult<&str, ()> {
+    alt((function_call, term))(input).map(|(input, _)| (input, ()))
+}
+
+fn function_call(input: &str) -> IResult<&str, ()> {
+    tuple((
+        name,
+        w(char_f('[')),
+        expression,
+        many0(tuple((w(char_f(',')), expression))),
+        w(char_f(']')),
+    ))(input)
+    .map(|(input, _)| (input, ()))
+}
+
+fn term(input: &str) -> IResult<&str, ()> {
+    alt((parens_expr, name, number))(input).map(|(input, _)| (input, ()))
+}
+
+fn parens_expr(input: &str) -> IResult<&str, ()> {
+    tuple((w(char_f('(')), expression, w(char_f(')'))))(input).map(|(input, _)| (input, ()))
+}
+
+fn number(input: &str) -> IResult<&str, ()> {
+    w(take_while(char::is_dec_digit))(input).map(|(input, _)| (input, ()))
+}
+
+fn name(input: &str) -> IResult<&str, ()> {
+    w(tuple((letter, many0(alt((letter, digit))))))(input).map(|(input, _)| (input, ()))
+}
+
+fn letter(input: &str) -> IResult<&str, ()> {
+    one_of("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")(input).map(|(input, _)| (input, ()))
+}
+
+fn digit(input: &str) -> IResult<&str, ()> {
+    one_of("0123456789")(input).map(|(input, _)| (input, ()))
+}
+
+#[cfg(test)]
+mod test {
+    use crate::parse::function_scripts::parser::parse_function_script;
+
+    #[test]
+    fn addition() {
+        let (input_left, _) = parse_function_script("1 + 2 + 3").unwrap();
+        assert!(input_left.is_empty());
+    }
+}

--- a/bve/src/parse/mesh/instructions/post_processing.rs
+++ b/bve/src/parse/mesh/instructions/post_processing.rs
@@ -129,7 +129,8 @@ fn process_compound(mesh: &[Instruction]) -> Vec<Instruction> {
                 // Faces
                 let vi = vertex_index;
 
-                let split = (n - 1).max(0) as usize;
+                // logically (n - 1).max(0) but that caused underflow
+                let split = (n.max(1) - 1) as usize;
                 for i in 0..split {
                     result.push(create_face(
                         instruction,

--- a/bve/src/parse/mesh/instructions/post_processing.rs
+++ b/bve/src/parse/mesh/instructions/post_processing.rs
@@ -129,8 +129,7 @@ fn process_compound(mesh: &[Instruction]) -> Vec<Instruction> {
                 // Faces
                 let vi = vertex_index;
 
-                // logically (n - 1).max(0) but that caused underflow
-                let split = (n.max(1) - 1) as usize;
+                let split = n.saturating_sub(1) as usize;
                 for i in 0..split {
                     result.push(create_face(
                         instruction,

--- a/bve/src/parse/mod.rs
+++ b/bve/src/parse/mod.rs
@@ -1,5 +1,6 @@
 //! File parsers, linters, and code generators
 
+pub mod function_scripts;
 pub mod mesh;
 mod util;
 

--- a/deny.toml
+++ b/deny.toml
@@ -13,6 +13,9 @@ allow = [
 
 [bans]
 multiple-versions = "deny"
+skip = [
+    { name = "nom", version = "4" },
+]
 
 [advisories]
 vulnerability = "deny"


### PR DESCRIPTION
This adds parsing for function scripts. It uses nom, a parser combinator, and as such is completely illegible, but it's compact and it works.

Depends on #27 