### PR TITLE
Add Key Value Pair Parsing Support

### DIFF
--- a/bve/src/parse/kvp/mod.rs
+++ b/bve/src/parse/kvp/mod.rs
@@ -24,7 +24,7 @@ impl Default for Section {
     fn default() -> Self {
         Self {
             name: None,
-            span: Span { line: Some(0) },
+            span: Span::from_line(0),
             values: Vec::default(),
         }
     }
@@ -61,9 +61,7 @@ pub fn parse_kvp_file(input: &str) -> KVPFile {
                     &mut current_section,
                     Section {
                         name: Some(name),
-                        span: Span {
-                            line: Some((line_idx + 1) as u64),
-                        },
+                        span: Span::from_line(line_idx + 1),
                         values: Vec::default(),
                     },
                 ));
@@ -86,9 +84,7 @@ pub fn parse_kvp_file(input: &str) -> KVPFile {
                 };
                 // Push data onto current section
                 current_section.values.push(Value {
-                    span: Span {
-                        line: Some((line_idx + 1) as u64),
-                    },
+                    span: Span::from_line(line_idx + 1),
                     data,
                 });
             }

--- a/bve/src/parse/kvp/mod.rs
+++ b/bve/src/parse/kvp/mod.rs
@@ -1,0 +1,104 @@
+//! Generic parser for key-value pair format. Not quite toml, not quite INI.
+
+use crate::parse::Span;
+
+pub struct KVPFile {
+    pub sections: Vec<Section>,
+}
+
+impl Default for KVPFile {
+    fn default() -> Self {
+        Self {
+            sections: Vec::default(),
+        }
+    }
+}
+
+pub struct Section {
+    pub name: Option<String>,
+    pub span: Span,
+    pub values: Vec<Value>,
+}
+
+impl Default for Section {
+    fn default() -> Self {
+        Self {
+            name: None,
+            span: Span { line: Some(0) },
+            values: Vec::default(),
+        }
+    }
+}
+
+pub struct Value {
+    pub span: Span,
+    pub data: ValueData,
+}
+
+pub enum ValueData {
+    KeyValuePair { key: String, value: String },
+    Value { value: String },
+}
+
+pub fn parse_kvp_file(input: &str) -> KVPFile {
+    let input = input.to_lowercase();
+
+    let mut file = KVPFile::default();
+    let mut current_section = Section::default();
+    for (line_idx, line) in input.lines().enumerate() {
+        // Match on the first character
+        match line.chars().next() {
+            Some('[') => {
+                // This is a section
+                let end = line.find(']');
+                let name = match end {
+                    // Allow there to be a missing ] in the section header
+                    Some(idx) => String::from(line[1..idx].trim()),
+                    None => String::from(line[1..].trim()),
+                };
+                // Simultaneously push the previous section and create this new one
+                file.sections.push(std::mem::replace(
+                    &mut current_section,
+                    Section {
+                        name: Some(name),
+                        span: Span {
+                            line: Some((line_idx + 1) as u64),
+                        },
+                        values: Vec::default(),
+                    },
+                ));
+            }
+            Some(..) => {
+                // This is a piece of data
+                let equals = line.find('=');
+                let data = match equals {
+                    // Key Value Pair
+                    Some(idx) => {
+                        let key = String::from(line[0..idx].trim());
+                        let value = String::from(line[(idx + 1)..].trim());
+                        ValueData::KeyValuePair { key, value }
+                    }
+                    // No Equals it's a Value
+                    None => {
+                        let value = String::from(line.trim());
+                        ValueData::Value { value }
+                    }
+                };
+                // Push data onto current section
+                current_section.values.push(Value {
+                    span: Span {
+                        line: Some((line_idx + 1) as u64),
+                    },
+                    data,
+                });
+            }
+            // Empty line, ignore it
+            None => {}
+        }
+    }
+
+    // Push the last section into the file
+    file.sections.push(current_section);
+
+    file
+}

--- a/bve/src/parse/kvp/mod.rs
+++ b/bve/src/parse/kvp/mod.rs
@@ -63,6 +63,8 @@ pub enum ValueData {
     Value { value: String },
 }
 
+#[must_use]
+#[allow(clippy::single_match_else)] // This advises less clear code
 pub fn parse_kvp_file(input: &str) -> KVPFile {
     let mut file = KVPFile::default();
     let mut current_section = Section::default();

--- a/bve/src/parse/mesh/instructions/post_processing.rs
+++ b/bve/src/parse/mesh/instructions/post_processing.rs
@@ -28,7 +28,7 @@ pub fn post_process(mut instructions: InstructionList) -> InstructionList {
         let mesh = process_compound(mesh);
         let mesh = merge_texture_coords(&mesh, &mut instructions.errors);
         output.push(Instruction {
-            span: Span { line: None },
+            span: Span::none(),
             data: InstructionData::CreateMeshBuilder(CreateMeshBuilder),
         });
         output.extend(mesh);

--- a/bve/src/parse/mesh/instructions/tests/instruction_creation.rs
+++ b/bve/src/parse/mesh/instructions/tests/instruction_creation.rs
@@ -81,7 +81,7 @@ macro_rules! instruction_assert {
             *result_a.instructions.get(0).unwrap(),
             Instruction {
                 data: $data,
-                span: Span { line: Some(1) }
+                span: Span::from_line(1),
             }
         );
         let result_b = create_instructions(concat!($inputCSV, ",", $args).into(), FileType::CSV);
@@ -95,7 +95,7 @@ macro_rules! instruction_assert {
             *result_b.instructions.get(0).unwrap(),
             Instruction {
                 data: $data,
-                span: Span { line: Some(1) }
+                span: Span::from_line(1),
             }
         );
     };

--- a/bve/src/parse/mesh/instructions/tests/mod.rs
+++ b/bve/src/parse/mesh/instructions/tests/mod.rs
@@ -19,7 +19,7 @@ fn generate_instructions_from_obj(input: &'static str) -> InstructionList {
 
     let obj: Obj<'_, SimplePolygon> = Obj::load_buf(&mut buf).expect("Unable to parse obj");
     let mut result = vec![Instruction {
-        span: Span { line: None },
+        span: Span::none(),
         data: InstructionData::CreateMeshBuilder(CreateMeshBuilder),
     }];
 
@@ -32,7 +32,7 @@ fn generate_instructions_from_obj(input: &'static str) -> InstructionList {
             let normal = obj.normal[vert.2.expect("OBJ must have normals")];
             let normal: Vector3<f32> = Vector3::new(normal[0], normal[1], normal[2]);
             result.push(Instruction {
-                span: Span { line: None },
+                span: Span::none(),
                 data: InstructionData::AddVertex(AddVertex {
                     position,
                     normal,
@@ -42,7 +42,7 @@ fn generate_instructions_from_obj(input: &'static str) -> InstructionList {
             let texture_coord = obj.texture[vert.1.expect("OBJ must have texture coords")];
             let texture_coord: Vector2<f32> = Vector2::new(texture_coord[0], texture_coord[1]);
             result.push(Instruction {
-                span: Span { line: None },
+                span: Span::none(),
                 data: InstructionData::SetTextureCoordinates(SetTextureCoordinates {
                     coords: texture_coord,
                     index: index_count + offset,
@@ -51,7 +51,7 @@ fn generate_instructions_from_obj(input: &'static str) -> InstructionList {
         }
         let face_vertices = face.len();
         result.push(Instruction {
-            span: Span { line: None },
+            span: Span::none(),
             data: InstructionData::AddFace(AddFace {
                 indexes: Vec::from_iter(index_count..(index_count + face_vertices)),
                 sides: Sides::One,

--- a/bve/src/parse/mod.rs
+++ b/bve/src/parse/mod.rs
@@ -1,6 +1,7 @@
 //! File parsers, linters, and code generators
 
 pub mod function_scripts;
+pub mod kvp;
 pub mod mesh;
 mod util;
 

--- a/bve/src/parse/util/span.rs
+++ b/bve/src/parse/util/span.rs
@@ -13,15 +13,18 @@ pub struct Span {
 }
 
 impl Span {
-    pub fn new() -> Self {
+    #[must_use]
+    pub const fn new() -> Self {
         Self { line: None }
     }
 
-    pub fn none() -> Self {
+    #[must_use]
+    pub const fn none() -> Self {
         Self { line: None }
     }
 
-    pub fn from_line(line: impl ToPrimitive) -> Self {
+    #[must_use]
+    pub fn from_line(line: impl ToPrimitive + Copy) -> Self {
         Self { line: line.to_u64() }
     }
 }

--- a/bve/src/parse/util/span.rs
+++ b/bve/src/parse/util/span.rs
@@ -1,13 +1,29 @@
+use num_traits::ToPrimitive;
+
 /// File location for errors/ast nodes
 ///
 /// Does not contain file information because they are already associated with an attempt to parse a file.
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub struct Span {
     /// Line of the location
     ///
     /// May be empty if there is no reasonable way to create a span for a construct.
     /// Empty spans generally should not be exposed to the user.
     pub line: Option<u64>,
+}
+
+impl Span {
+    pub fn new() -> Self {
+        Self { line: None }
+    }
+
+    pub fn none() -> Self {
+        Self { line: None }
+    }
+
+    pub fn from_line(line: impl ToPrimitive) -> Self {
+        Self { line: line.to_u64() }
+    }
 }
 
 impl<'a> From<Option<&'a csv::Position>> for Span {


### PR DESCRIPTION
This adds a basic format parser used in a lot of other formats in BVE. This is a simple key-value pair file with support for values with no keys and sections. Duplicates allowed everywhere.

This parser merely deserializes the file, it gives no meaning to it.

Depends on #29 