### PR TITLE
Add Animated Files to Corpus Tester and Fix Associated Bugs

### DIFF
--- a/bve-corpus/src/logger.rs
+++ b/bve-corpus/src/logger.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::mem_forget)]
+
 use crate::{FileKind, FileResult, Options, ParseResult};
 use crossbeam::channel::Receiver;
 use serde::Serialize;

--- a/bve-corpus/src/logger.rs
+++ b/bve-corpus/src/logger.rs
@@ -1,12 +1,18 @@
-use crate::{FileResult, Options, ParseResult};
+use crate::{FileKind, FileResult, Options, ParseResult};
 use crossbeam::channel::Receiver;
 use serde::Serialize;
 use std::cmp::Reverse;
+use std::collections::HashMap;
 use std::fs::write;
 use std::path::PathBuf;
 
 #[derive(Debug, Default, Clone, Serialize)]
 struct ResultCollection {
+    file_types: HashMap<FileKind, SingleFileCollection>,
+}
+
+#[derive(Debug, Default, Clone, Serialize)]
+struct SingleFileCollection {
     successes: Vec<PathBuf>,
     failures: Vec<Failure>,
     panics: Vec<Panic>,
@@ -25,36 +31,48 @@ struct Panic {
     cause: String,
 }
 
-pub fn receive_results(options: &Options, result_source: &Receiver<FileResult>) {
+pub fn receive_results(options: &Options, result_source: Receiver<FileResult>) {
     let mut results = ResultCollection::default();
 
     while let Ok(result) = result_source.recv() {
+        let single_file_result = results.file_types.entry(result.kind).or_default();
         match result.result {
-            ParseResult::Success => results.successes.push(result.path),
-            ParseResult::Errors { count, error } => results.failures.push(Failure {
+            ParseResult::Success => single_file_result.successes.push(result.path),
+            ParseResult::Errors { count, error } => single_file_result.failures.push(Failure {
                 error: error.to_string(),
                 count,
                 path: result.path,
             }),
-            ParseResult::Panic { cause } => results.panics.push(Panic {
+            ParseResult::Panic { cause } => single_file_result.panics.push(Panic {
                 cause,
                 path: result.path,
             }),
-            ParseResult::Finish => break,
+            ParseResult::Finish => {
+                std::mem::forget(result_source); // We're finishing, we don't actually care about if this is cleaned up, and this prevents a out-of-time panic cascade 
+                break;
+            }
         }
     }
 
-    results.failures.retain(|v| v.count != 0);
+    let (panics, failures, successes) = results
+        .file_types
+        .values_mut()
+        .map(|single| {
+            single
+                .failures
+                .sort_by_cached_key(|v| Reverse((v.count, v.path.clone())));
 
-    results
-        .failures
-        .sort_by_cached_key(|v| Reverse((v.count, v.path.clone())));
+            (single.panics.len(), single.failures.len(), single.successes.len())
+        })
+        .fold((0, 0, 0), |(acc_p, acc_f, acc_s), (p, f, s)| {
+            (acc_p + p, acc_f + f, acc_s + s)
+        });
 
-    println!("Panics: {}", results.panics.len());
-    println!("Failures: {}", results.failures.len());
-    println!("Successes: {}", results.successes.len());
+    println!("Panics: {}", panics);
+    println!("Failures: {}", failures);
+    println!("Successes: {}", successes);
 
     if let Some(output) = &options.output {
-        write(output, serde_json::to_string_pretty(&results.failures).unwrap()).unwrap();
+        write(output, serde_json::to_string_pretty(&results).unwrap()).unwrap();
     }
 }

--- a/bve-corpus/src/main.rs
+++ b/bve-corpus/src/main.rs
@@ -52,7 +52,7 @@ use crate::enumeration::enumerate_all_files;
 use crate::panic::setup_panic_hook;
 use crate::worker::create_worker_thread;
 use anyhow::Result;
-use bve::log::{run_with_global_logger, set_global_logger, SerializationMethod, Subscriber};
+use bve::log::{run_with_global_logger, set_global_logger, Level, SerializationMethod, Subscriber};
 use crossbeam::channel::unbounded;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 pub use options::*;
@@ -136,7 +136,7 @@ fn main() {
 
     let options: Options = Options::from_args();
 
-    let _guard = set_global_logger(std::io::sink(), SerializationMethod::JsonPretty);
+    let _guard = set_global_logger(std::io::sink(), Level::WARN, SerializationMethod::JsonPretty);
 
     run_with_global_logger(move || program_main(options));
 }

--- a/bve-derive/src/test.rs
+++ b/bve-derive/src/test.rs
@@ -21,7 +21,7 @@ pub fn test(item: TokenStream) -> TokenStream {
                 task();
             } else {
                 // Manually dispatch to avoid non-thread-local state
-                let subscriber = crate::log::Subscriber::new(::std::io::stderr(), crate::log::SerializationMethod::JsonPretty);
+                let subscriber = crate::log::Subscriber::new(::std::io::stderr(), crate::log::Level::TRACE, crate::log::SerializationMethod::JsonPretty);
                 ::tracing::dispatcher::with_default(&::tracing::dispatcher::Dispatch::new(subscriber),
                     task
                 );

--- a/bve/src/log/mod.rs
+++ b/bve/src/log/mod.rs
@@ -7,6 +7,7 @@ pub use data::*;
 pub use global::*;
 pub use method::*;
 pub use subscriber::*;
+pub use tracing_core::Level;
 
 mod common;
 mod data;

--- a/bve/src/parse/animated/mod.rs
+++ b/bve/src/parse/animated/mod.rs
@@ -1,11 +1,13 @@
 use crate::parse::kvp::{parse_kvp_file, FromKVPFile, KVPGenericWarning};
+use crate::parse::util::strip_comments;
 pub use structs::*;
 
 mod structs;
 
 #[must_use]
 pub fn parse_animated_file(input: &str) -> (ParsedAnimatedObject, Vec<KVPGenericWarning>) {
-    let kvp_file = parse_kvp_file(input);
+    let lower = strip_comments(input, ';').to_lowercase();
+    let kvp_file = parse_kvp_file(&lower);
 
     ParsedAnimatedObject::from_kvp_file(&kvp_file)
 }

--- a/bve/src/parse/animated/structs.rs
+++ b/bve/src/parse/animated/structs.rs
@@ -6,7 +6,8 @@ use num_traits::identities::Zero;
 
 #[derive(Debug, Default, Clone, PartialEq, FromKVPFile)]
 pub struct ParsedAnimatedObject {
-    pub includes: Includes,
+    #[kvp(rename = "include")]
+    pub includes: Vec<Includes>,
     #[kvp(rename = "object")]
     pub objects: Vec<AnimatedObject>,
     #[kvp(rename = "sound")]


### PR DESCRIPTION
Nothing terribly of note, besides the conversion of the logging channel from unbounded to bounded to remove memory "leak".