### PR TITLE
Train Dat Program To Read train.dat

### DIFF
--- a/bve-derive/src/kvp.rs
+++ b/bve-derive/src/kvp.rs
@@ -125,6 +125,7 @@ pub fn kvp_file(item: TokenStream) -> TokenStream {
     }));
 
     quote! (
+        #[automatically_derived]
         impl crate::parse::kvp::FromKVPFile for #ident {
             type Warnings = crate::parse::kvp::KVPGenericWarning;
             fn from_kvp_file(file: &crate::parse::kvp::KVPFile<'_>) -> (Self, Vec<Self::Warnings>) {
@@ -265,6 +266,7 @@ pub fn kvp_section(item: TokenStream) -> TokenStream {
     }));
 
     quote! (
+        #[automatically_derived]
         impl crate::parse::kvp::FromKVPSection for #ident {
             type Warnings = crate::parse::kvp::KVPGenericWarning;
             fn from_kvp_section(section: &crate::parse::kvp::KVPSection<'_>) -> (Self, Vec<Self::Warnings>) {
@@ -318,6 +320,7 @@ pub fn kvp_value(item: TokenStream) -> TokenStream {
     }));
 
     quote! (
+        #[automatically_derived]
         impl crate::parse::kvp::FromKVPValue for #ident {
             fn from_kvp_value(value: &str) -> Option<Self> {
                 let mut iterator = value.split(',').map(str::trim);

--- a/bve-derive/src/kvp.rs
+++ b/bve-derive/src/kvp.rs
@@ -23,6 +23,7 @@ fn split_aliases(input: String) -> Vec<String> {
     }
 }
 
+/// Struct field with possible attributes as returned by [`parse_fields`]
 #[derive(Debug, FromField)]
 #[darling(attributes(kvp))]
 struct Field {
@@ -337,6 +338,7 @@ pub fn kvp_value(item: TokenStream) -> TokenStream {
     .into()
 }
 
+/// Enum variants with possible attributes as used by [`kvp_enum_numbers`]
 #[derive(Debug, FromVariant)]
 #[darling(attributes(kvp))]
 struct Variant {

--- a/bve-derive/src/kvp.rs
+++ b/bve-derive/src/kvp.rs
@@ -126,6 +126,7 @@ pub fn kvp_file(item: TokenStream) -> TokenStream {
 
     quote! (
         #[automatically_derived]
+        #[allow(clippy::used_underscore_binding)]
         impl crate::parse::kvp::FromKVPFile for #ident {
             type Warnings = crate::parse::kvp::KVPGenericWarning;
             fn from_kvp_file(file: &crate::parse::kvp::KVPFile<'_>) -> (Self, Vec<Self::Warnings>) {
@@ -267,6 +268,7 @@ pub fn kvp_section(item: TokenStream) -> TokenStream {
 
     quote! (
         #[automatically_derived]
+        #[allow(clippy::used_underscore_binding)]
         impl crate::parse::kvp::FromKVPSection for #ident {
             type Warnings = crate::parse::kvp::KVPGenericWarning;
             fn from_kvp_section(section: &crate::parse::kvp::KVPSection<'_>) -> (Self, Vec<Self::Warnings>) {
@@ -321,6 +323,7 @@ pub fn kvp_value(item: TokenStream) -> TokenStream {
 
     quote! (
         #[automatically_derived]
+        #[allow(clippy::used_underscore_binding)]
         impl crate::parse::kvp::FromKVPValue for #ident {
             fn from_kvp_value(value: &str) -> Option<Self> {
                 let mut iterator = value.split(',').map(str::trim);
@@ -397,6 +400,7 @@ pub fn kvp_enum_numbers(item: TokenStream) -> TokenStream {
 
     quote! (
         #[automatically_derived]
+        #[allow(clippy::used_underscore_binding)]
         impl crate::parse::kvp::FromKVPValue for #ident {
             fn from_kvp_value(value: &str) -> Option<Self> {
                 let number = <i64 as crate::parse::kvp::FromKVPValue>::from_kvp_value(value)?;

--- a/bve-derive/src/kvp.rs
+++ b/bve-derive/src/kvp.rs
@@ -8,11 +8,11 @@
 #![allow(clippy::default_trait_access)] // Needed by darling
 
 use crate::helpers::combine_token_streams;
-use darling::FromField;
+use darling::{FromField, FromVariant};
 use proc_macro2::Ident;
 use quote::quote;
 use syn::export::{TokenStream, TokenStream2};
-use syn::{GenericArgument, ItemStruct, PathArguments, Type};
+use syn::{GenericArgument, ItemEnum, ItemStruct, PathArguments, Type};
 
 #[allow(clippy::needless_pass_by_value)] // Needed for type deduction
 fn split_aliases(input: String) -> Vec<String> {
@@ -330,6 +330,85 @@ pub fn kvp_value(item: TokenStream) -> TokenStream {
                 })
             }
         }
+    )
+    .into()
+}
+
+#[derive(Debug, FromVariant)]
+#[darling(attributes(kvp))]
+struct Variant {
+    ident: Ident,
+    #[darling(default)]
+    default: bool,
+    #[darling(default)]
+    index: Option<i64>,
+}
+
+pub fn kvp_enum_numbers(item: TokenStream) -> TokenStream {
+    let item = syn::parse_macro_input!(item as ItemEnum);
+
+    let ident = item.ident;
+
+    let fields: Vec<Variant> = item
+        .variants
+        .iter()
+        .map(Variant::from_variant)
+        .filter_map(Result::ok)
+        .collect();
+
+    let default_count = fields.iter().filter(|v| v.default).count();
+    assert!(default_count <= 1, "Must not have more than one default field");
+
+    let default_impl = if default_count == 1 {
+        let default_ident = fields
+            .iter()
+            .find(|v| v.default)
+            .expect("Must have a default value")
+            .ident
+            .clone();
+        quote! {
+            #[automatically_derived]
+            impl std::default::Default for #ident {
+                fn default() -> Self {
+                    Self::#default_ident
+                }
+            }
+        }
+    } else {
+        quote! {}
+    };
+
+    let mut idx = 0_i64;
+
+    let matches = combine_token_streams(fields.iter().map(|variant| {
+        let ident = variant.ident.clone();
+
+        if let Some(replacement_idx) = variant.index {
+            idx = replacement_idx;
+        }
+
+        let new_idx = idx + 1;
+        let idx = std::mem::replace(&mut idx, new_idx);
+
+        quote! {
+            #idx => Self::#ident,
+        }
+    }));
+
+    quote! (
+        #[automatically_derived]
+        impl crate::parse::kvp::FromKVPValue for #ident {
+            fn from_kvp_value(value: &str) -> Option<Self> {
+                let number = <i64 as crate::parse::kvp::FromKVPValue>::from_kvp_value(value)?;
+
+                Some(match number {
+                    #matches
+                    _ => return None,
+                })
+            }
+        }
+
+        #default_impl
     )
     .into()
 }

--- a/bve-derive/src/kvp.rs
+++ b/bve-derive/src/kvp.rs
@@ -338,7 +338,7 @@ pub fn kvp_value(item: TokenStream) -> TokenStream {
     .into()
 }
 
-/// Enum variants with possible attributes as used by [`kvp_enum_numbers`]
+/// Enum variant with possible attributes as used by [`kvp_enum_numbers`]
 #[derive(Debug, FromVariant)]
 #[darling(attributes(kvp))]
 struct Variant {

--- a/bve-derive/src/lib.rs
+++ b/bve-derive/src/lib.rs
@@ -119,3 +119,9 @@ pub fn from_kvp_section(item: TokenStream) -> TokenStream {
 pub fn from_kvp_value(item: TokenStream) -> TokenStream {
     kvp::kvp_value(item)
 }
+
+#[proc_macro_derive(FromKVPValueEnumNumbers, attributes(kvp))]
+#[cfg_attr(tarpaulin, skip)]
+pub fn from_kvp_value_enum_numbers(item: TokenStream) -> TokenStream {
+    kvp::kvp_enum_numbers(item)
+}

--- a/bve-derive/src/lib.rs
+++ b/bve-derive/src/lib.rs
@@ -113,3 +113,9 @@ pub fn from_kvp_file(item: TokenStream) -> TokenStream {
 pub fn from_kvp_section(item: TokenStream) -> TokenStream {
     kvp::kvp_section(item)
 }
+
+#[proc_macro_derive(FromKVPValue, attributes(kvp))]
+#[cfg_attr(tarpaulin, skip)]
+pub fn from_kvp_value(item: TokenStream) -> TokenStream {
+    kvp::kvp_value(item)
+}

--- a/bve-derive/src/serde_proxy.rs
+++ b/bve-derive/src/serde_proxy.rs
@@ -309,6 +309,7 @@ fn generate_proxy_object(name: &Ident, fields: &[Field]) -> TokenStream2 {
             #proxy_fields
         }
 
+        #[automatically_derived]
         impl ::std::convert::From<#proxy_name> for #name {
             #[inline]
             fn from(proxy: #proxy_name) -> #name {
@@ -465,6 +466,7 @@ pub fn serde_vector_proxy(item: TokenStream) -> TokenStream {
         #[serde(from = #primary_type_str)]
         #parsed
 
+        #[automatically_derived]
         impl ::std::convert::From<#primary_type> for #name {
             #[allow(clippy::default_trait_access)]
             fn from(proxy: #primary_type) -> Self {

--- a/bve/src/parse/animated/mod.rs
+++ b/bve/src/parse/animated/mod.rs
@@ -1,4 +1,4 @@
-use crate::parse::kvp::{parse_kvp_file, FromKVPFile, KVPGenericWarning};
+use crate::parse::kvp::{parse_kvp_file, FromKVPFile, KVPGenericWarning, ANIMATED_LIKE};
 use crate::parse::util::strip_comments;
 pub use structs::*;
 
@@ -7,7 +7,7 @@ mod structs;
 #[must_use]
 pub fn parse_animated_file(input: &str) -> (ParsedAnimatedObject, Vec<KVPGenericWarning>) {
     let lower = strip_comments(input, ';').to_lowercase();
-    let kvp_file = parse_kvp_file(&lower);
+    let kvp_file = parse_kvp_file(&lower, ANIMATED_LIKE);
 
     ParsedAnimatedObject::from_kvp_file(&kvp_file)
 }

--- a/bve/src/parse/animated/structs.rs
+++ b/bve/src/parse/animated/structs.rs
@@ -1,6 +1,6 @@
 use crate::parse::function_scripts::ParsedFunctionScript;
 use crate::parse::kvp::FromKVPValue;
-use bve_derive::{FromKVPFile, FromKVPSection};
+use bve_derive::{FromKVPFile, FromKVPSection, FromKVPValue};
 use cgmath::{Vector2, Vector3};
 use num_traits::identities::Zero;
 
@@ -159,19 +159,10 @@ impl Default for AnimatedStateChangeSound {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, FromKVPValue)]
 pub struct Damping {
     pub frequency: f32,
     pub damping_ratio: f32,
-}
-
-impl FromKVPValue for Damping {
-    fn from_kvp_value(value: &str) -> Option<Self> {
-        Vector2::<f32>::from_kvp_value(value).map(|vec| Self {
-            frequency: vec.x,
-            damping_ratio: vec.y,
-        })
-    }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/bve/src/parse/kvp/parse.rs
+++ b/bve/src/parse/kvp/parse.rs
@@ -1,7 +1,7 @@
 use crate::parse::kvp::{KVPField, KVPFile, KVPSection, ValueData};
 use crate::parse::Span;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Copy, Clone)]
 pub struct KVPSymbols {
     start_section: char,
     end_section: Option<char>,

--- a/bve/src/parse/kvp/tests/mod.rs
+++ b/bve/src/parse/kvp/tests/mod.rs
@@ -3,7 +3,7 @@
 #![allow(clippy::shadow_unrelated)] // These are tests
 
 use crate::parse::kvp::traits::FromKVPFile;
-use crate::parse::kvp::{parse_kvp_file, KVPGenericWarning, KVPGenericWarningKind};
+use crate::parse::kvp::{parse_kvp_file, KVPGenericWarning, KVPGenericWarningKind, ANIMATED_LIKE};
 use crate::parse::Span;
 use bve_derive::{FromKVPFile, FromKVPSection};
 use indoc::indoc;
@@ -19,7 +19,7 @@ fn empty_struct() {
     "#
     );
 
-    let kvp = parse_kvp_file(file_lit);
+    let kvp = parse_kvp_file(file_lit, ANIMATED_LIKE);
     let (parsed, warnings) = File::from_kvp_file(&kvp);
     assert_eq!(parsed, File::default());
     assert_eq!(warnings, vec![]);
@@ -48,7 +48,7 @@ fn bare_section_value() {
     "#
     );
 
-    let kvp = parse_kvp_file(file_lit);
+    let kvp = parse_kvp_file(file_lit, ANIMATED_LIKE);
     let (parsed, warnings) = File::from_kvp_file(&kvp);
     let mut answer = File::default();
     answer.first.some1 = 6.2;
@@ -76,7 +76,7 @@ fn bare_section_kvp() {
     "#
     );
 
-    let kvp = parse_kvp_file(file_lit);
+    let kvp = parse_kvp_file(file_lit, ANIMATED_LIKE);
     let (parsed, warnings) = File::from_kvp_file(&kvp);
     let mut answer = File::default();
     answer.first.some = 6.7;
@@ -107,7 +107,7 @@ fn single_section_value() {
     "#
     );
 
-    let kvp = parse_kvp_file(file_lit);
+    let kvp = parse_kvp_file(file_lit, ANIMATED_LIKE);
     let (parsed, warnings) = File::from_kvp_file(&kvp);
     let mut answer = File::default();
     answer.first.some1 = 6.2;
@@ -135,7 +135,7 @@ fn single_section_kvp() {
     "#
     );
 
-    let kvp = parse_kvp_file(file_lit);
+    let kvp = parse_kvp_file(file_lit, ANIMATED_LIKE);
     let (parsed, warnings) = File::from_kvp_file(&kvp);
     let mut answer = File::default();
     answer.first.some = 6.7;
@@ -170,7 +170,7 @@ fn single_section_mixed() {
     "#
     );
 
-    let kvp = parse_kvp_file(file_lit);
+    let kvp = parse_kvp_file(file_lit, ANIMATED_LIKE);
     let (parsed, warnings) = File::from_kvp_file(&kvp);
     let mut answer = File::default();
     answer.first.kvp1 = 1.1;
@@ -190,7 +190,7 @@ fn single_section_mixed() {
     "#
     );
 
-    let kvp = parse_kvp_file(file_lit);
+    let kvp = parse_kvp_file(file_lit, ANIMATED_LIKE);
     let (parsed, warnings) = File::from_kvp_file(&kvp);
     let mut answer = File::default();
     answer.first.kvp1 = 1.1;
@@ -222,7 +222,7 @@ fn additive_value() {
     "#
     );
 
-    let kvp = parse_kvp_file(file_lit);
+    let kvp = parse_kvp_file(file_lit, ANIMATED_LIKE);
     let (parsed, warnings) = File::from_kvp_file(&kvp);
     let mut answer = File::default();
     answer.first.some1 = vec![6.2, 6.7];
@@ -252,7 +252,7 @@ fn additive_kvp() {
     "#
     );
 
-    let kvp = parse_kvp_file(file_lit);
+    let kvp = parse_kvp_file(file_lit, ANIMATED_LIKE);
     let (parsed, warnings) = File::from_kvp_file(&kvp);
     let mut answer = File::default();
     answer.first.kvp1 = vec![6.2, 6.7];
@@ -281,7 +281,7 @@ fn alias_kvp() {
     "#
     );
 
-    let kvp = parse_kvp_file(file_lit);
+    let kvp = parse_kvp_file(file_lit, ANIMATED_LIKE);
     let (parsed, warnings) = File::from_kvp_file(&kvp);
     let mut answer = File::default();
     answer.first.some = 6.7;
@@ -309,7 +309,7 @@ fn section_alias() {
     "#
     );
 
-    let kvp = parse_kvp_file(file_lit);
+    let kvp = parse_kvp_file(file_lit, ANIMATED_LIKE);
     let (parsed, warnings) = File::from_kvp_file(&kvp);
     let mut answer = File::default();
     answer.first.some = 6.7;
@@ -328,7 +328,7 @@ fn unknown_section() {
     "#
     );
 
-    let kvp = parse_kvp_file(file_lit);
+    let kvp = parse_kvp_file(file_lit, ANIMATED_LIKE);
     let (parsed, warnings) = File::from_kvp_file(&kvp);
     assert_eq!(parsed, File::default());
     assert_eq!(
@@ -347,7 +347,7 @@ fn unknown_section() {
     "#
     );
 
-    let kvp = parse_kvp_file(file_lit);
+    let kvp = parse_kvp_file(file_lit, ANIMATED_LIKE);
     let (parsed, warnings) = File::from_kvp_file(&kvp);
     assert_eq!(parsed, File::default());
     assert_eq!(
@@ -378,7 +378,7 @@ fn unknown_field() {
     "#
     );
 
-    let kvp = parse_kvp_file(file_lit);
+    let kvp = parse_kvp_file(file_lit, ANIMATED_LIKE);
     let (parsed, warnings) = File::from_kvp_file(&kvp);
     assert_eq!(parsed, File::default());
     assert_eq!(
@@ -397,7 +397,7 @@ fn unknown_field() {
     "#
     );
 
-    let kvp = parse_kvp_file(file_lit);
+    let kvp = parse_kvp_file(file_lit, ANIMATED_LIKE);
     let (parsed, warnings) = File::from_kvp_file(&kvp);
     assert_eq!(parsed, File::default());
     assert_eq!(
@@ -431,7 +431,7 @@ fn invalid_value() {
     "#
     );
 
-    let kvp = parse_kvp_file(file_lit);
+    let kvp = parse_kvp_file(file_lit, ANIMATED_LIKE);
     let (parsed, warnings) = File::from_kvp_file(&kvp);
     assert_eq!(parsed, File::default());
     assert_eq!(
@@ -464,7 +464,7 @@ fn invalid_kvp_value() {
     "#
     );
 
-    let kvp = parse_kvp_file(file_lit);
+    let kvp = parse_kvp_file(file_lit, ANIMATED_LIKE);
     let (parsed, warnings) = File::from_kvp_file(&kvp);
     assert_eq!(parsed, File::default());
     assert_eq!(

--- a/bve/src/parse/mod.rs
+++ b/bve/src/parse/mod.rs
@@ -4,6 +4,7 @@ pub mod animated;
 pub mod function_scripts;
 pub mod kvp;
 pub mod mesh;
+pub mod train_dat;
 mod util;
 
 pub use util::Span;

--- a/bve/src/parse/train_dat/mod.rs
+++ b/bve/src/parse/train_dat/mod.rs
@@ -1,0 +1,3 @@
+pub use sections::*;
+
+mod sections;

--- a/bve/src/parse/train_dat/mod.rs
+++ b/bve/src/parse/train_dat/mod.rs
@@ -1,3 +1,13 @@
+use crate::parse::kvp::{parse_kvp_file, FromKVPFile, KVPGenericWarning, DAT_LIKE};
+use crate::parse::util::strip_comments;
 pub use sections::*;
 
 mod sections;
+
+#[must_use]
+pub fn parse_train_dat(input: &str) -> (ParsedTrainDat, Vec<KVPGenericWarning>) {
+    let lower = strip_comments(input, ';').to_lowercase();
+    let kvp_file = parse_kvp_file(&lower, DAT_LIKE);
+
+    ParsedTrainDat::from_kvp_file(&kvp_file)
+}

--- a/bve/src/parse/train_dat/sections/acceleration.rs
+++ b/bve/src/parse/train_dat/sections/acceleration.rs
@@ -1,5 +1,4 @@
-use crate::parse::kvp::FromKVPValue;
-use bve_derive::{FromKVPFile, FromKVPSection, FromKVPValue};
+use bve_derive::{FromKVPSection, FromKVPValue};
 
 #[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
 pub struct AccelerationSection {

--- a/bve/src/parse/train_dat/sections/acceleration.rs
+++ b/bve/src/parse/train_dat/sections/acceleration.rs
@@ -1,0 +1,23 @@
+use crate::parse::kvp::FromKVPValue;
+use bve_derive::{FromKVPFile, FromKVPSection, FromKVPValue};
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
+pub struct AccelerationSection {
+    #[kvp(bare)]
+    pub acceleration_points: Vec<AccelerationPoint>,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPValue)]
+pub struct AccelerationPoint {
+    /// A positive floating-point number representing the acceleration at a speed of 0 km/h expressed in km/h/s.
+    pub a0: f32,
+    /// A positive floating-point number representing the acceleration at a speed of v1 expressed in km/h/s.
+    pub a1: f32,
+    /// A positive floating-point number representing a reference speed in km/h corresponding to a1.
+    pub v1: f32,
+    /// A positive floating-point number representing a reference speed in km/h corresponding to e.
+    pub v2: f32,
+    /// A positive floating-point number representing an exponent. The behavior is different for version 1.22 and
+    /// version 2.0 file formats.
+    pub e: f32,
+}

--- a/bve/src/parse/train_dat/sections/brake.rs
+++ b/bve/src/parse/train_dat/sections/brake.rs
@@ -1,0 +1,30 @@
+use bve_derive::{FromKVPSection, FromKVPValueEnumNumbers};
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
+pub struct BrakeSection {
+    #[kvp(bare)]
+    pub brake_type: BrakeType,
+    #[kvp(bare)]
+    pub brake_control_system: BrakeControlSystem,
+    #[kvp(bare)]
+    pub brake_control_speed: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
+pub enum BrakeType {
+    #[kvp(default)]
+    /// Electromagnetic straight air brake
+    Electromagnetic,
+    /// Digital/analog electro-pneumatic air brake without brake pipe (electric command brake)
+    ElectricPneumatic,
+    /// Air brake with partial release feature
+    AirPartial,
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
+pub enum BrakeControlSystem {
+    #[kvp(default)]
+    None,
+    ClosingElectromagneticValve,
+    DelayIncludingControl,
+}

--- a/bve/src/parse/train_dat/sections/cab.rs
+++ b/bve/src/parse/train_dat/sections/cab.rs
@@ -1,0 +1,23 @@
+use bve_derive::FromKVPSection;
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
+pub struct CabSection {
+    /// A floating-point number measured in millimeters (mm) which gives the X-coordinate of the driver’s eye from the
+    /// center of the driver’s car. Negative values indicate a location on the left side of the train, positive ones on
+    /// the right side.
+    #[kvp(bare)]
+    x: f32,
+    /// A floating-point number measured in millimeters (mm) which gives the Y-coordinate of the driver’s eye from the
+    /// top of the rails. Negative values indicate a location below the top of the rails, positive ones above the top
+    /// of the rails.
+    #[kvp(bare)]
+    y: f32,
+    /// A floating-point number measured in millimeters (mm) which gives the Z-coordinate of the driver’s eye from the
+    /// front of the driver’s car. Negative values indicate a location inside the car, positive ones outside.
+    #[kvp(bare)]
+    z: f32,
+    /// A non-negative integer indicating which car the driver is located in. The first car in the train has index 0,
+    /// the second car index 1, and so on.
+    #[kvp(bare)]
+    car: u64,
+}

--- a/bve/src/parse/train_dat/sections/delay.rs
+++ b/bve/src/parse/train_dat/sections/delay.rs
@@ -1,5 +1,4 @@
-use crate::parse::kvp::FromKVPValue;
-use bve_derive::{FromKVPFile, FromKVPSection, FromKVPValue};
+use bve_derive::FromKVPSection;
 
 #[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
 pub struct DelaySection {

--- a/bve/src/parse/train_dat/sections/delay.rs
+++ b/bve/src/parse/train_dat/sections/delay.rs
@@ -1,0 +1,14 @@
+use crate::parse::kvp::FromKVPValue;
+use bve_derive::{FromKVPFile, FromKVPSection, FromKVPValue};
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
+pub struct DelaySection {
+    #[kvp(bare, variadic)]
+    pub delay_power_up: Vec<f32>,
+    #[kvp(bare, variadic)]
+    pub delay_power_down: Vec<f32>,
+    #[kvp(bare, variadic)]
+    pub delay_brake_up: Vec<f32>,
+    #[kvp(bare, variadic)]
+    pub delay_brake_down: Vec<f32>,
+}

--- a/bve/src/parse/train_dat/sections/device.rs
+++ b/bve/src/parse/train_dat/sections/device.rs
@@ -1,0 +1,94 @@
+use bve_derive::{FromKVPSection, FromKVPValueEnumNumbers};
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
+pub struct DeviceSection {
+    #[kvp(bare)]
+    ats: AtsAvailable,
+    #[kvp(bare)]
+    atc: AtcAvailable,
+    #[kvp(bare)]
+    eb: EbAvailable,
+    #[kvp(bare)]
+    const_speed: ConstSpeedAvailable,
+    #[kvp(bare)]
+    hold_brake: HoldBrakeAvailable,
+    #[kvp(bare)]
+    re_adhesion_device: ReAdhesionDeviceType,
+    #[kvp(bare)]
+    load_compensating_device: String,
+    #[kvp(bare)]
+    pass_alarm: PassAlarmType,
+    #[kvp(bare)]
+    door_open_mode: DoorMode,
+    #[kvp(bare)]
+    door_close_mode: DoorMode,
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
+pub enum AtsAvailable {
+    #[kvp(default, index = "-1")]
+    Neither,
+    AtsSn,
+    Both,
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
+pub enum AtcAvailable {
+    #[kvp(default)]
+    Unavailable,
+    Manual,
+    Automatic,
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
+pub enum EbAvailable {
+    #[kvp(default)]
+    Unavailable,
+    Available,
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
+pub enum ConstSpeedAvailable {
+    #[kvp(default)]
+    Unavailable,
+    Available,
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
+pub enum HoldBrakeAvailable {
+    #[kvp(default)]
+    Unavailable,
+    Available,
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
+pub enum ReAdhesionDeviceType {
+    #[kvp(default, index = "-1")]
+    Unavailable,
+    /// Cuts off power instantly and rebuilds it up fast in steps.
+    TypeA,
+    /// Updates not so often and adapts slowly. Wheel slip can persist longer and power is regained slower. The
+    /// behavior is smoother.
+    TypeB,
+    /// The behavior is somewhere in-between type B and type D.
+    TypeC,
+    /// Updates fast and adapts fast. Wheel slip only occurs briefly and power is regained fast. The behavior is more
+    /// abrupt.
+    TypeD,
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
+pub enum PassAlarmType {
+    #[kvp(default)]
+    Unavailable,
+    Single,
+    Loop,
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
+pub enum DoorMode {
+    #[kvp(default)]
+    AutomaticOrManual,
+    AutomaticOnly,
+    ManualOnly,
+}

--- a/bve/src/parse/train_dat/sections/device.rs
+++ b/bve/src/parse/train_dat/sections/device.rs
@@ -7,7 +7,7 @@ pub struct DeviceSection {
     #[kvp(bare)]
     atc: AtcAvailable,
     #[kvp(bare)]
-    eb: EbAvailable,
+    eb: EmergencyBrakeAvailable,
     #[kvp(bare)]
     const_speed: ConstSpeedAvailable,
     #[kvp(bare)]
@@ -24,14 +24,16 @@ pub struct DeviceSection {
     door_close_mode: DoorMode,
 }
 
+/// Japanese implementation of digital Automatic Train Stops, supports ATS-SN and ATS-P
 #[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
 pub enum AtsAvailable {
     #[kvp(default, index = "-1")]
     Neither,
     AtsSn,
-    Both,
+    AtsSnAtsP,
 }
 
+/// Japanese implementation of digital Automatic Train Control
 #[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
 pub enum AtcAvailable {
     #[kvp(default)]
@@ -41,7 +43,7 @@ pub enum AtcAvailable {
 }
 
 #[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
-pub enum EbAvailable {
+pub enum EmergencyBrakeAvailable {
     #[kvp(default)]
     Unavailable,
     Available,

--- a/bve/src/parse/train_dat/sections/handle.rs
+++ b/bve/src/parse/train_dat/sections/handle.rs
@@ -1,0 +1,43 @@
+use bve_derive::{FromKVPSection, FromKVPValueEnumNumbers};
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
+pub struct HandleSection {
+    #[kvp(bare)]
+    pub handle_type: HandleType,
+    #[kvp(bare)]
+    pub power_notches: u64,
+    #[kvp(bare)]
+    pub brake_notches: u64,
+    #[kvp(bare)]
+    pub power_notch_reduce_steps: u64,
+    #[kvp(bare)]
+    pub emergency_brake_handle_behavior: EmergencyBrakeHandleBehavior,
+    #[kvp(bare)]
+    pub loco_brake_notches: u64,
+    #[kvp(bare)]
+    pub loco_brake_type: LocoBrakeType,
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
+pub enum HandleType {
+    #[kvp(default)]
+    Separate,
+    Combined,
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
+pub enum EmergencyBrakeHandleBehavior {
+    #[kvp(default)]
+    NoAction,
+    PowerToNeutral,
+    ReverserToNeutral,
+    PowerAndReverserToNeutral,
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
+pub enum LocoBrakeType {
+    #[kvp(default)]
+    Combined,
+    Independent,
+    Blocking,
+}

--- a/bve/src/parse/train_dat/sections/mod.rs
+++ b/bve/src/parse/train_dat/sections/mod.rs
@@ -1,0 +1,20 @@
+use crate::parse::kvp::FromKVPValue;
+use bve_derive::{FromKVPFile, FromKVPSection, FromKVPValue};
+
+pub mod acceleration;
+pub mod delay;
+pub mod movement;
+pub mod performance;
+pub mod version;
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPFile)]
+pub struct ParsedTrainDat {
+    #[kvp(bare)]
+    pub version: version::VersionSection,
+    pub acceleration: acceleration::AccelerationSection,
+    #[kvp(alias = "deceleration")]
+    pub performance: performance::PerformanceSection,
+    pub delay: delay::DelaySection,
+    #[kvp(rename = "move")] // move is a keyword
+    pub movement: movement::MovementSection,
+}

--- a/bve/src/parse/train_dat/sections/mod.rs
+++ b/bve/src/parse/train_dat/sections/mod.rs
@@ -1,10 +1,15 @@
-use crate::parse::kvp::FromKVPValue;
-use bve_derive::{FromKVPFile, FromKVPSection, FromKVPValue};
+use bve_derive::FromKVPFile;
 
 pub mod acceleration;
+pub mod brake;
+pub mod cab;
 pub mod delay;
+pub mod device;
+pub mod handle;
+pub mod motor;
 pub mod movement;
 pub mod performance;
+pub mod pressure;
 pub mod version;
 
 #[derive(Debug, Default, Clone, PartialEq, FromKVPFile)]
@@ -17,4 +22,13 @@ pub struct ParsedTrainDat {
     pub delay: delay::DelaySection,
     #[kvp(rename = "move")] // move is a keyword
     pub movement: movement::MovementSection,
+    pub brake: brake::BrakeSection,
+    pub pressure: pressure::PressureSection,
+    pub handle: handle::HandleSection,
+    #[kvp(alias = "cab; cockpit")]
+    pub cab: cab::CabSection,
+    pub motor_p1: motor::MotorSection,
+    pub motor_p2: motor::MotorSection,
+    pub motor_b1: motor::MotorSection,
+    pub motor_b2: motor::MotorSection,
 }

--- a/bve/src/parse/train_dat/sections/motor.rs
+++ b/bve/src/parse/train_dat/sections/motor.rs
@@ -1,0 +1,15 @@
+use bve_derive::{FromKVPSection, FromKVPValue};
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
+pub struct MotorSection {
+    #[kvp(bare)]
+    sound_data: Vec<MotorSoundType>,
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValue)]
+pub struct MotorSoundType {
+    sound_index: i64,
+    /// Really just sound speed
+    pitch: f32,
+    volume: f32,
+}

--- a/bve/src/parse/train_dat/sections/movement.rs
+++ b/bve/src/parse/train_dat/sections/movement.rs
@@ -1,5 +1,4 @@
-use crate::parse::kvp::FromKVPValue;
-use bve_derive::{FromKVPFile, FromKVPSection, FromKVPValue};
+use bve_derive::FromKVPSection;
 
 #[derive(Debug, Clone, PartialEq, FromKVPSection)]
 pub struct MovementSection {

--- a/bve/src/parse/train_dat/sections/movement.rs
+++ b/bve/src/parse/train_dat/sections/movement.rs
@@ -1,0 +1,31 @@
+use crate::parse::kvp::FromKVPValue;
+use bve_derive::{FromKVPFile, FromKVPSection, FromKVPValue};
+
+#[derive(Debug, Clone, PartialEq, FromKVPSection)]
+pub struct MovementSection {
+    #[kvp(bare)]
+    pub jerk_power_up: f32,
+    #[kvp(bare)]
+    pub jerk_power_down: f32,
+    #[kvp(bare)]
+    pub jerk_brake_up: f32,
+    #[kvp(bare)]
+    pub jerk_brake_down: f32,
+    #[kvp(bare)]
+    pub brake_cylinder_up: f32,
+    #[kvp(bare)]
+    pub brake_cylinder_down: f32,
+}
+
+impl Default for MovementSection {
+    fn default() -> Self {
+        Self {
+            jerk_power_up: 1000.0,
+            jerk_power_down: 1000.0,
+            jerk_brake_up: 1000.0,
+            jerk_brake_down: 1000.0,
+            brake_cylinder_up: 300.0,
+            brake_cylinder_down: 200.0,
+        }
+    }
+}

--- a/bve/src/parse/train_dat/sections/performance.rs
+++ b/bve/src/parse/train_dat/sections/performance.rs
@@ -1,0 +1,28 @@
+use crate::parse::kvp::FromKVPValue;
+use bve_derive::{FromKVPFile, FromKVPSection, FromKVPValue};
+
+#[derive(Debug, Clone, PartialEq, FromKVPSection)]
+pub struct PerformanceSection {
+    #[kvp(bare)]
+    pub deceleration: f32,
+    #[kvp(bare)]
+    pub coefficient_of_static_friction: f32,
+    #[kvp(bare)]
+    pub _reserved0: f32,
+    #[kvp(bare)]
+    pub coefficient_of_rolling_resistance: f32,
+    #[kvp(bare)]
+    pub aerodynamic_drag_coefficient: f32,
+}
+
+impl Default for PerformanceSection {
+    fn default() -> Self {
+        Self {
+            deceleration: 1.0,
+            coefficient_of_static_friction: 0.35,
+            _reserved0: 0.0,
+            coefficient_of_rolling_resistance: 0.0025,
+            aerodynamic_drag_coefficient: 1.1,
+        }
+    }
+}

--- a/bve/src/parse/train_dat/sections/performance.rs
+++ b/bve/src/parse/train_dat/sections/performance.rs
@@ -1,5 +1,4 @@
-use crate::parse::kvp::FromKVPValue;
-use bve_derive::{FromKVPFile, FromKVPSection, FromKVPValue};
+use bve_derive::FromKVPSection;
 
 #[derive(Debug, Clone, PartialEq, FromKVPSection)]
 pub struct PerformanceSection {

--- a/bve/src/parse/train_dat/sections/pressure.rs
+++ b/bve/src/parse/train_dat/sections/pressure.rs
@@ -1,0 +1,27 @@
+use bve_derive::FromKVPSection;
+
+#[derive(Debug, Clone, PartialEq, FromKVPSection)]
+pub struct PressureSection {
+    #[kvp(bare)]
+    brake_cylinder_service_maximum_pressure: f32,
+    #[kvp(bare)]
+    brake_cylinder_emergency_maximum_pressure: f32,
+    #[kvp(bare)]
+    main_reservoir_minimum_pressure: f32,
+    #[kvp(bare)]
+    main_reservoir_maximum_pressure: f32,
+    #[kvp(bare)]
+    brake_pipe_normal_pressure: f32,
+}
+
+impl Default for PressureSection {
+    fn default() -> Self {
+        Self {
+            brake_cylinder_service_maximum_pressure: 480.0,
+            brake_cylinder_emergency_maximum_pressure: 480.0,
+            main_reservoir_minimum_pressure: 690.0,
+            main_reservoir_maximum_pressure: 780.0,
+            brake_pipe_normal_pressure: 490.0,
+        }
+    }
+}

--- a/bve/src/parse/train_dat/sections/version.rs
+++ b/bve/src/parse/train_dat/sections/version.rs
@@ -1,5 +1,5 @@
 use crate::parse::kvp::FromKVPValue;
-use bve_derive::{FromKVPFile, FromKVPSection, FromKVPValue};
+use bve_derive::FromKVPSection;
 
 #[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
 pub struct VersionSection {

--- a/bve/src/parse/train_dat/sections/version.rs
+++ b/bve/src/parse/train_dat/sections/version.rs
@@ -1,0 +1,43 @@
+use crate::parse::kvp::FromKVPValue;
+use bve_derive::{FromKVPFile, FromKVPSection, FromKVPValue};
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
+pub struct VersionSection {
+    #[kvp(bare)]
+    pub version: Version,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Version {
+    BVE120,
+    BVE121,
+    BVE122,
+    BVE2,
+    OpenBVE { version: String },
+}
+
+impl Default for Version {
+    fn default() -> Self {
+        Self::BVE2
+    }
+}
+
+impl FromKVPValue for Version {
+    fn from_kvp_value(value: &str) -> Option<Self> {
+        match value {
+            "bve1200000" => Some(Self::BVE120),
+            "bve1210000" => Some(Self::BVE121),
+            "bve1220000" => Some(Self::BVE122),
+            "bve2000000" | "openbve" => Some(Self::BVE2),
+            _ => {
+                if value.starts_with("openbve") {
+                    Some(Self::OpenBVE {
+                        version: String::from(&value[7..]),
+                    })
+                } else {
+                    None
+                }
+            }
+        }
+    }
+}

--- a/bve/src/parse/train_dat/sections/version.rs
+++ b/bve/src/parse/train_dat/sections/version.rs
@@ -24,20 +24,15 @@ impl Default for Version {
 
 impl FromKVPValue for Version {
     fn from_kvp_value(value: &str) -> Option<Self> {
-        match value {
-            "bve1200000" => Some(Self::BVE120),
-            "bve1210000" => Some(Self::BVE121),
-            "bve1220000" => Some(Self::BVE122),
-            "bve2000000" | "openbve" => Some(Self::BVE2),
-            _ => {
-                if value.starts_with("openbve") {
-                    Some(Self::OpenBVE {
-                        version: String::from(&value[7..]),
-                    })
-                } else {
-                    None
-                }
-            }
-        }
+        Some(match value {
+            "bve1200000" => Self::BVE120,
+            "bve1210000" => Self::BVE121,
+            "bve1220000" => Self::BVE122,
+            "bve2000000" | "openbve" => Self::BVE2,
+            _ if value.starts_with("openbve") => Self::OpenBVE {
+                version: String::from(&value[7..]),
+            },
+            _ => return None,
+        })
     }
 }


### PR DESCRIPTION
I'm sorry.

This adds support for parsing train.dat using the standard kvp parser. Notable additions to be looked at:

- Added FromKVPValueEnumNumbers that takes an enum and creates it from a i64. It has the ability to change the index, but follows rust's enum numbering scheme and just increments from there.
- Made KVP parser generic over the symbols it looks for the start and end of a section, as well as the separator between key and value.
- Other than that the rest of the PR is a pretty bland transcription of the docs.

There will be hella bugs with this, but corpus testing is next.