### PR TITLE
Convert KVP Parser to Loose Numbers

### DIFF
--- a/bve/src/parse/kvp/tests/mod.rs
+++ b/bve/src/parse/kvp/tests/mod.rs
@@ -427,7 +427,7 @@ fn invalid_value() {
 
     let file_lit = indoc!(
         r#"
-        62.3
+        |62.3
     "#
     );
 
@@ -439,7 +439,7 @@ fn invalid_value() {
         vec![KVPGenericWarning {
             span: Span::from_line(1),
             kind: KVPGenericWarningKind::InvalidValue {
-                value: String::from("62.3"),
+                value: String::from("|62.3"),
             }
         }]
     );
@@ -460,7 +460,7 @@ fn invalid_kvp_value() {
 
     let file_lit = indoc!(
         r#"
-        known = 62.3
+        known = |62.3
     "#
     );
 
@@ -472,7 +472,7 @@ fn invalid_kvp_value() {
         vec![KVPGenericWarning {
             span: Span::from_line(1),
             kind: KVPGenericWarningKind::InvalidValue {
-                value: String::from("62.3"),
+                value: String::from("|62.3"),
             }
         }]
     );

--- a/bve/src/parse/kvp/traits.rs
+++ b/bve/src/parse/kvp/traits.rs
@@ -1,7 +1,7 @@
 use crate::parse::kvp::{KVPFile, KVPSection};
+use crate::parse::util::{parse_loose_number, parse_loose_numeric_bool};
 use crate::parse::Span;
 use cgmath::{Vector1, Vector2, Vector3, Vector4};
-use std::str::FromStr;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct KVPGenericWarning {
@@ -36,17 +36,23 @@ pub trait FromKVPValue {
 }
 
 macro_rules! impl_from_kvp_value_primitive {
-    ($($int:ident),+) => {$(
-        impl FromKVPValue for $int
+    ($($prim:ident),+) => {$(
+        impl FromKVPValue for $prim
         {
-            fn from_kvp_value(value: &str) -> Option<$int> {
-                $int::from_str(value).ok()
+            fn from_kvp_value(value: &str) -> Option<$prim> {
+                parse_loose_number::<$prim>(value).map(|v| v.0)
             }
         }
     )*};
 }
 
 impl_from_kvp_value_primitive!(u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, usize, isize, f32, f64);
+
+impl FromKVPValue for bool {
+    fn from_kvp_value(value: &str) -> Option<Self> {
+        parse_loose_numeric_bool(value).map(|v| v.0)
+    }
+}
 
 impl<T> FromKVPValue for Option<T>
 where


### PR DESCRIPTION
This PR makes BVE worse.

This forces all KVP parsers to use loose numbers. This means they accept really shittily formed numbers. This works because `strict` (i.e. normal) numbers are a subset of loose numbers, so if it parses as a strict number, it parses as a loose number.