### PR TITLE
Add Parsing Support for Extensions.cfg

### DIFF
--- a/bve-corpus/src/worker/mod.rs
+++ b/bve-corpus/src/worker/mod.rs
@@ -2,6 +2,7 @@ use crate::panic::{PANIC, USE_DEFAULT_PANIC_HANLDER};
 use crate::{File, FileKind, FileResult, ParseResult, SharedData};
 use bve::filesystem::read_convert_utf8;
 use bve::parse::animated::parse_animated_file;
+use bve::parse::extensions_cfg::parse_extensions_cfg;
 use bve::parse::kvp::parse_kvp_file;
 use bve::parse::mesh::{mesh_from_str, FileType, MeshErrorKind, ParsedStaticObject};
 use bve::parse::train_dat::parse_train_dat;
@@ -120,6 +121,13 @@ fn processing_loop(
                 let (_parsed, warnings) = parse_train_dat(&file_contents);
 
                 shared.train_dat.finished.fetch_add(1, Ordering::AcqRel);
+
+                success_or_errors(warnings)
+            }
+            FileKind::ExtensionsCfg => {
+                let (_parsed, warnings) = parse_extensions_cfg(&file_contents);
+
+                shared.extensions_cfg.finished.fetch_add(1, Ordering::AcqRel);
 
                 success_or_errors(warnings)
             }

--- a/bve-derive/src/kvp.rs
+++ b/bve-derive/src/kvp.rs
@@ -23,6 +23,19 @@ fn split_aliases(input: String) -> Vec<String> {
     }
 }
 
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+enum FieldKind {
+    Normal,
+    Vec,
+    Hash,
+}
+
+impl Default for FieldKind {
+    fn default() -> Self {
+        Self::Normal
+    }
+}
+
 /// Struct field with possible attributes as returned by [`parse_fields`]
 #[derive(Debug, FromField)]
 #[darling(attributes(kvp))]
@@ -30,7 +43,7 @@ struct Field {
     ident: Option<Ident>,
     ty: Type,
     #[darling(skip)]
-    vec: bool,
+    kind: FieldKind,
     #[darling(default)]
     bare: bool,
     #[darling(default)]
@@ -45,14 +58,26 @@ fn parse_fields(item: &ItemStruct) -> Vec<Field> {
     let fields = item.fields.iter().flat_map(Field::from_field);
     let fields: Vec<Field> = fields
         .map(|mut field: Field| {
-            if let Type::Path(path) = &field.ty {
+            if let Type::Path(path) = field.ty.clone() {
                 let segments = path.path.segments.last().expect("No path segments found");
                 let last_path_str = segments.ident.to_string();
                 if last_path_str == "Vec" && !field.variadic {
-                    field.vec = true;
+                    field.kind = FieldKind::Vec;
                     match &segments.arguments {
                         PathArguments::AngleBracketed(angled) => {
                             match angled.args.first().expect("Generic must have args") {
+                                GenericArgument::Type(ty) => field.ty = ty.clone(),
+                                _ => unimplemented!(),
+                            }
+                        }
+                        _ => unimplemented!(),
+                    }
+                }
+                if last_path_str == "HashMap" {
+                    field.kind = FieldKind::Hash;
+                    match &segments.arguments {
+                        PathArguments::AngleBracketed(angled) => {
+                            match angled.args.last().expect("Generic must have args") {
                                 GenericArgument::Type(ty) => field.ty = ty.clone(),
                                 _ => unimplemented!(),
                             }
@@ -85,17 +110,25 @@ pub fn kvp_file(item: TokenStream) -> TokenStream {
     let matches = combine_token_streams(fields.iter().map(|field| {
         let ty = field.ty.clone();
         let ident = field.ident.clone().expect("Fields must have names");
-        let primary = match &field.bare {
+
+        let non_bare_ident: String = field.rename.as_ref().map_or_else(
+            || ident.to_string().chars().filter(|&c| c != '_').collect(),
+            String::clone,
+        );
+        let non_bare_ident_len = non_bare_ident.len();
+
+        let primary = match (&field.bare, &field.kind) {
             // The bare section just uses None as a name
-            true => quote! {None},
+            (true, _) => quote! {None},
             // Named sections are matched directly
-            false => {
-                let lower: String = field.rename.as_ref().map_or_else(
-                    || ident.to_string().chars().filter(|&c| c != '_').collect(),
-                    String::clone,
-                );
+            (false, FieldKind::Hash) => {
                 quote! {
-                    Some(#lower)
+                    Some(section_name) if section_name.starts_with(#non_bare_ident) && !section_name[#non_bare_ident_len..].chars().any(|c| !c.is_digit(10))
+                }
+            }
+            (false, _) => {
+                quote! {
+                    Some(#non_bare_ident)
                 }
             }
         };
@@ -106,14 +139,20 @@ pub fn kvp_file(item: TokenStream) -> TokenStream {
             }
         }));
         // Vec fields need to be pushed onto, whereas regular fields need to be assigned.
-        let operation = match field.vec {
-            true => quote! {{
+        let operation = match field.kind {
+            FieldKind::Vec => quote! {{
                 let (section_ty, section_warnings) = <#ty as crate::parse::kvp::FromKVPSection>::from_kvp_section(section);
                 parsed.#ident.push(section_ty);
                 // All section warnings need to be pushed onto the end of the file warnings
                 warnings.extend(section_warnings);
             }},
-            false => quote! {{
+            FieldKind::Hash => quote! {{
+                let (section_ty, section_warnings) = <#ty as crate::parse::kvp::FromKVPSection>::from_kvp_section(section);
+                parsed.#ident.insert(u64::parse(section_name[#non_bare_ident_len..]).expect("Unable to parse section name id"), section_ty);
+                // All section warnings need to be pushed onto the end of the file warnings
+                warnings.extend(section_warnings);
+            }},
+            FieldKind::Normal => quote! {{
                 let (section_ty, section_warnings) = <#ty as crate::parse::kvp::FromKVPSection>::from_kvp_section(section);
                 parsed.#ident = section_ty;
                 warnings.extend(section_warnings);
@@ -175,7 +214,7 @@ pub fn kvp_section(item: TokenStream) -> TokenStream {
 
     // Error Checking
 
-    let exists_bare_and_vec = fields.iter().filter(|f| f.bare && f.vec).count() >= 1;
+    let exists_bare_and_vec = fields.iter().filter(|f| f.bare && f.kind == FieldKind::Vec).count() >= 1;
     let more_than_one_bare_field = fields.iter().filter(|f| f.bare).count() > 1;
     if exists_bare_and_vec && more_than_one_bare_field {
         panic!("If there are any fields that are bare and of type Vec<T>, there must be only one bare field");
@@ -198,10 +237,12 @@ pub fn kvp_section(item: TokenStream) -> TokenStream {
             true => {
                 // If a bare field is a vector, then it is the only bare field, and all values
                 // should unconditionally shoved into it.
-                let ts = if field.vec {
+                let ts = if field.kind == FieldKind::Vec {
                     quote! {crate::parse::kvp::ValueData::Value{ value }}
-                } else {
+                } else if field.kind == FieldKind::Normal {
                     quote! {crate::parse::kvp::ValueData::Value{ value } if bare_counter == #bare_field_counter}
+                } else {
+                    unreachable!();
                 };
                 bare_field_counter += 1;
                 ts
@@ -230,8 +271,8 @@ pub fn kvp_section(item: TokenStream) -> TokenStream {
             TokenStream2::new()
         };
         // Vec fields need to be pushed onto, whereas regular fields need to be assigned.
-        let operation = match field.vec {
-            true => quote! {{
+        let operation = match field.kind {
+            FieldKind::Vec => quote! {{
                 let optional = <#ty as crate::parse::kvp::FromKVPValue>::from_kvp_value(value);
                 // Push a warning if the conversion from a value fails
                 if let Some(inner) = optional {
@@ -246,7 +287,7 @@ pub fn kvp_section(item: TokenStream) -> TokenStream {
                 };
                 #bare_operation
             }},
-            false => quote! {{
+            FieldKind::Normal => quote! {{
                 let optional = <#ty as crate::parse::kvp::FromKVPValue>::from_kvp_value(value);
                 if let Some(inner) = optional {
                     parsed.#ident = inner;
@@ -260,6 +301,7 @@ pub fn kvp_section(item: TokenStream) -> TokenStream {
                 };
                 #bare_operation
             }},
+            _ => unreachable!(),
         };
         // Hey look ma, a match arm
         quote! {

--- a/bve-derive/src/kvp.rs
+++ b/bve-derive/src/kvp.rs
@@ -126,7 +126,7 @@ pub fn kvp_file(item: TokenStream) -> TokenStream {
                     Some(section_name)
                         if section_name.starts_with(#non_bare_ident) // Starts with the name we want
                         && section_name.len() > #non_bare_ident_len // Has at least 1 more character than the name (there must be a number)
-                        && !section_name[#non_bare_ident_len..].chars().any(|c| !c.is_digit(10)) // All of the other characters are chars
+                        && !section_name[#non_bare_ident_len..].trim().chars().any(|c| !c.is_digit(10)) // All of the other characters are chars
                 }
             }
             (false, _) => {
@@ -151,7 +151,7 @@ pub fn kvp_file(item: TokenStream) -> TokenStream {
             }},
             FieldKind::Hash => quote! {{
                 let (section_ty, section_warnings) = <#ty as crate::parse::kvp::FromKVPSection>::from_kvp_section(section);
-                parsed.#ident.insert(<u64 as std::str::FromStr>::from_str(&section_name[#non_bare_ident_len..]).expect("Unable to parse section name id"), section_ty);
+                parsed.#ident.insert(<u64 as std::str::FromStr>::from_str(&section_name[#non_bare_ident_len..].trim()).expect("Unable to parse section name id"), section_ty);
                 // All section warnings need to be pushed onto the end of the file warnings
                 warnings.extend(section_warnings);
             }},
@@ -261,8 +261,14 @@ pub fn kvp_section(item: TokenStream) -> TokenStream {
                     || ident.to_string().chars().filter(|&c| c != '_').collect(),
                     String::clone,
                 );
-                quote! {
-                    crate::parse::kvp::ValueData::KeyValuePair{ key: #lower, value }
+                if field.kind == FieldKind::Hash {
+                    quote! {
+                        crate::parse::kvp::ValueData::KeyValuePair{ key, value }
+                    }
+                } else {
+                    quote! {
+                        crate::parse::kvp::ValueData::KeyValuePair{ key: #lower, value }
+                    }
                 }
             }
         };
@@ -296,13 +302,6 @@ pub fn kvp_section(item: TokenStream) -> TokenStream {
                 #bare_operation
             }},
             FieldKind::Hash => quote! {{
-                // Workaround how exactly the match works. Would be too difficult to fully change
-                let key = if let crate::parse::kvp::ValueData::KeyValuePair{ key, .. } = field.data {
-                    key
-                } else {
-                    unreachable!();
-                };
-
                 let key_optional = <u64 as crate::parse::kvp::FromKVPValue>::from_kvp_value(key);
                 let value_optional = <#ty as crate::parse::kvp::FromKVPValue>::from_kvp_value(value);
 

--- a/bve-derive/src/kvp.rs
+++ b/bve-derive/src/kvp.rs
@@ -67,10 +67,10 @@ fn parse_fields(item: &ItemStruct) -> Vec<Field> {
                         PathArguments::AngleBracketed(angled) => {
                             match angled.args.first().expect("Generic must have args") {
                                 GenericArgument::Type(ty) => field.ty = ty.clone(),
-                                _ => unimplemented!(),
+                                _ => unreachable!("Vec takes a single type argument"),
                             }
                         }
-                        _ => unimplemented!(),
+                        _ => unreachable!("Vec takes a single angle bracketed argument"),
                     }
                 }
                 if last_path_str == "HashMap" {
@@ -79,10 +79,10 @@ fn parse_fields(item: &ItemStruct) -> Vec<Field> {
                         PathArguments::AngleBracketed(angled) => {
                             match angled.args.last().expect("Generic must have args") {
                                 GenericArgument::Type(ty) => field.ty = ty.clone(),
-                                _ => unimplemented!(),
+                                _ => unreachable!("HashMap takes two type arguments"),
                             }
                         }
-                        _ => unimplemented!(),
+                        _ => unreachable!("HashMap takes two angle bracketed arguments"),
                     }
                 }
             };
@@ -250,7 +250,7 @@ pub fn kvp_section(item: TokenStream) -> TokenStream {
                 } else if field.kind == FieldKind::Normal {
                     quote! {crate::parse::kvp::ValueData::Value{ value } if bare_counter == #bare_field_counter}
                 } else {
-                    unreachable!();
+                    unreachable!("Only regular and Vec fields are allowed to be bare");
                 };
                 bare_field_counter += 1;
                 ts

--- a/bve-derive/src/kvp.rs
+++ b/bve-derive/src/kvp.rs
@@ -123,7 +123,10 @@ pub fn kvp_file(item: TokenStream) -> TokenStream {
             // Named sections are matched directly
             (false, FieldKind::Hash) => {
                 quote! {
-                    Some(section_name) if section_name.starts_with(#non_bare_ident) && !section_name[#non_bare_ident_len..].chars().any(|c| !c.is_digit(10))
+                    Some(section_name)
+                        if section_name.starts_with(#non_bare_ident) // Starts with the name we want
+                        && section_name.len() > #non_bare_ident_len // Has at least 1 more character than the name (there must be a number)
+                        && !section_name[#non_bare_ident_len..].chars().any(|c| !c.is_digit(10)) // All of the other characters are chars
                 }
             }
             (false, _) => {
@@ -148,7 +151,7 @@ pub fn kvp_file(item: TokenStream) -> TokenStream {
             }},
             FieldKind::Hash => quote! {{
                 let (section_ty, section_warnings) = <#ty as crate::parse::kvp::FromKVPSection>::from_kvp_section(section);
-                parsed.#ident.insert(u64::parse(section_name[#non_bare_ident_len..]).expect("Unable to parse section name id"), section_ty);
+                parsed.#ident.insert(<u64 as std::str::FromStr>::from_str(&section_name[#non_bare_ident_len..]).expect("Unable to parse section name id"), section_ty);
                 // All section warnings need to be pushed onto the end of the file warnings
                 warnings.extend(section_warnings);
             }},

--- a/bve/src/parse/extensions_cfg/mod.rs
+++ b/bve/src/parse/extensions_cfg/mod.rs
@@ -1,0 +1,3 @@
+pub use sections::*;
+
+mod sections;

--- a/bve/src/parse/extensions_cfg/mod.rs
+++ b/bve/src/parse/extensions_cfg/mod.rs
@@ -1,3 +1,13 @@
+use crate::parse::kvp::{parse_kvp_file, FromKVPFile, KVPGenericWarning, ANIMATED_LIKE};
+use crate::parse::util::strip_comments;
 pub use sections::*;
 
 mod sections;
+
+#[must_use]
+pub fn parse_extensions_cfg(input: &str) -> (ParsedExtensionsCfg, Vec<KVPGenericWarning>) {
+    let lower = strip_comments(input, ';').to_lowercase();
+    let kvp_file = parse_kvp_file(&lower, ANIMATED_LIKE);
+
+    ParsedExtensionsCfg::from_kvp_file(&kvp_file)
+}

--- a/bve/src/parse/extensions_cfg/sections/car.rs
+++ b/bve/src/parse/extensions_cfg/sections/car.rs
@@ -1,0 +1,4 @@
+use bve_derive::FromKVPSection;
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
+pub struct CarSection {}

--- a/bve/src/parse/extensions_cfg/sections/car.rs
+++ b/bve/src/parse/extensions_cfg/sections/car.rs
@@ -1,4 +1,18 @@
-use bve_derive::FromKVPSection;
+use bve_derive::{FromKVPSection, FromKVPValue};
 
 #[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
-pub struct CarSection {}
+pub struct CarSection {
+    #[kvp(rename = "object")]
+    pub object_filename: String,
+    pub length: f32,
+    #[kvp(rename = "axles")]
+    pub axle_positions: AxlePositions,
+    pub reversed: bool,
+    pub loading_sway: bool,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPValue)]
+pub struct AxlePositions {
+    pub rear: f32,
+    pub front: f32,
+}

--- a/bve/src/parse/extensions_cfg/sections/car.rs
+++ b/bve/src/parse/extensions_cfg/sections/car.rs
@@ -3,7 +3,7 @@ use bve_derive::{FromKVPSection, FromKVPValue};
 #[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
 pub struct CarSection {
     #[kvp(rename = "object")]
-    pub object_filename: String,
+    pub object_filename: Option<String>,
     pub length: f32,
     #[kvp(rename = "axles")]
     pub axle_positions: AxlePositions,

--- a/bve/src/parse/extensions_cfg/sections/coupler.rs
+++ b/bve/src/parse/extensions_cfg/sections/coupler.rs
@@ -1,0 +1,12 @@
+use bve_derive::{FromKVPSection, FromKVPValue};
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
+pub struct CouplerSection {
+    pub distances: Distances,
+}
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPValue)]
+pub struct Distances {
+    minimum: f32,
+    maximum: f32,
+}

--- a/bve/src/parse/extensions_cfg/sections/exterior.rs
+++ b/bve/src/parse/extensions_cfg/sections/exterior.rs
@@ -1,0 +1,7 @@
+use bve_derive::FromKVPSection;
+use std::collections::HashMap;
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
+pub struct ExteriorSection {
+    cars: HashMap<u64, String>,
+}

--- a/bve/src/parse/extensions_cfg/sections/mod.rs
+++ b/bve/src/parse/extensions_cfg/sections/mod.rs
@@ -12,5 +12,5 @@ pub struct ParsedExtensionsCfg {
     #[kvp(rename = "coupler")]
     pub couplers: HashMap<u64, coupler::CouplerSection>,
     #[kvp(rename = "exterior")]
-    pub exteriors: HashMap<u64, exterior::ExteriorSection>,
+    pub exteriors: exterior::ExteriorSection,
 }

--- a/bve/src/parse/extensions_cfg/sections/mod.rs
+++ b/bve/src/parse/extensions_cfg/sections/mod.rs
@@ -2,9 +2,15 @@ use bve_derive::FromKVPFile;
 use std::collections::HashMap;
 
 pub mod car;
+pub mod coupler;
+pub mod exterior;
 
 #[derive(Debug, Default, Clone, PartialEq, FromKVPFile)]
 pub struct ParsedExtensionsCfg {
     #[kvp(rename = "car")]
     pub cars: HashMap<u64, car::CarSection>,
+    #[kvp(rename = "coupler")]
+    pub couplers: HashMap<u64, coupler::CouplerSection>,
+    #[kvp(rename = "exterior")]
+    pub exteriors: HashMap<u64, exterior::ExteriorSection>,
 }

--- a/bve/src/parse/extensions_cfg/sections/mod.rs
+++ b/bve/src/parse/extensions_cfg/sections/mod.rs
@@ -1,0 +1,10 @@
+use bve_derive::FromKVPFile;
+use std::collections::HashMap;
+
+pub mod car;
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPFile)]
+pub struct ParsedExtensionsCfg {
+    #[kvp(rename = "car")]
+    pub cars: HashMap<u64, car::CarSection>,
+}

--- a/bve/src/parse/mod.rs
+++ b/bve/src/parse/mod.rs
@@ -1,6 +1,7 @@
 //! File parsers, linters, and code generators
 
 pub mod animated;
+pub mod extensions_cfg;
 pub mod function_scripts;
 pub mod kvp;
 pub mod mesh;

--- a/bve/src/parse/util/numeric_bool.rs
+++ b/bve/src/parse/util/numeric_bool.rs
@@ -40,6 +40,12 @@ pub fn parse_loose_numeric_bool(input: &str) -> Option<LooseNumericBool> {
 
     let mut filtered: String = input.chars().filter(|c| !c.is_whitespace()).collect();
 
+    match filtered.as_str() {
+        s if s[0..1] == 't' || s[0..1] == 'T' => return Some(LooseNumericBool(true)),
+        s if s[0..1] == 'f' || s[0..1] == 'F' => return Some(LooseNumericBool(false)),
+        _ => {}
+    }
+
     while !filtered.is_empty() {
         let parsed: Result<i64, _> = filtered.parse();
         match parsed {

--- a/bve/src/parse/util/numeric_bool.rs
+++ b/bve/src/parse/util/numeric_bool.rs
@@ -40,9 +40,10 @@ pub fn parse_loose_numeric_bool(input: &str) -> Option<LooseNumericBool> {
 
     let mut filtered: String = input.chars().filter(|c| !c.is_whitespace()).collect();
 
-    match filtered.as_str() {
-        s if s[0..1] == 't' || s[0..1] == 'T' => return Some(LooseNumericBool(true)),
-        s if s[0..1] == 'f' || s[0..1] == 'F' => return Some(LooseNumericBool(false)),
+    let first_letter = filtered.chars().next().as_ref().map(char::to_ascii_lowercase);
+    match first_letter {
+        Some('t') => return Some(LooseNumericBool(true)),
+        Some('f') => return Some(LooseNumericBool(false)),
         _ => {}
     }
 
@@ -63,7 +64,7 @@ pub fn parse_loose_numeric_bool(input: &str) -> Option<LooseNumericBool> {
 
 #[cfg(test)]
 mod test {
-    use crate::parse::util::LooseNumericBool;
+    use crate::parse::util::{parse_loose_numeric_bool, LooseNumericBool};
     use serde_test::{assert_de_tokens, Token};
 
     #[bve_derive::bve_test]
@@ -77,5 +78,10 @@ mod test {
         assert_de_tokens(&b, &[Token::Str("1")]);
         assert_de_tokens(&b, &[Token::Str("1xxxx0")]);
         assert_de_tokens(&b, &[Token::Str("1.1")]);
+        assert_eq!(parse_loose_numeric_bool(""), None);
+        assert_eq!(parse_loose_numeric_bool("True"), Some(LooseNumericBool(true)));
+        assert_eq!(parse_loose_numeric_bool("False"), Some(LooseNumericBool(false)));
+        assert_eq!(parse_loose_numeric_bool("t"), Some(LooseNumericBool(true)));
+        assert_eq!(parse_loose_numeric_bool("f"), Some(LooseNumericBool(false)));
     }
 }


### PR DESCRIPTION
Pretty standard PR at this point. Adds extensions.cfg support, expands the kvp derives, adds it to the corpus tester, fixes the bugs found in the wild.