### PR TITLE
Add Localization Machinery

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,9 @@
 name: build
 on: [push, pull_request]
 
+env:
+  RUST_BACKTRACE: full
+
 jobs:
   build:
     name: ${{ matrix.name }}

--- a/.github/workflows/repo-state.yml
+++ b/.github/workflows/repo-state.yml
@@ -7,6 +7,9 @@ on:
       - 'update-**'
       - 'ci-**'
 
+env:
+  RUST_BACKTRACE: full
+
 jobs:
   build:
     name: ${{ matrix.tool }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,7 @@ dependencies = [
  "nom 5.1.1",
  "num-traits",
  "obj",
+ "once_cell",
  "serde",
  "serde_json",
  "serde_plain",
@@ -1006,6 +1007,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c03f145738a183bf53d24b6d943c861fb045fe2c231c60832419fa0eb2c8e183"
 
 [[package]]
+name = "once_cell"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c601810575c99596d4afc46f78a678c80105117c379eb3650cf99b8a21ce5b"
+
+[[package]]
 name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1581,6 +1588,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d81136159f779c35b10655f45210c71cd5ca5a45aadfe9840a61c7071735ed"
 dependencies = [
  "unic-langid-impl",
+ "unic-langid-macros",
 ]
 
 [[package]]
@@ -1590,6 +1598,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c43c61e94492eb67f20facc7b025778a904de83d953d8fcb60dd9adfd6e2d0ea"
 dependencies = [
  "tinystr",
+]
+
+[[package]]
+name = "unic-langid-macros"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49bd90791278634d57e3ed4a4073108e3f79bfb87ab6a7b8664ba097425703df"
+dependencies = [
+ "proc-macro-hack",
+ "tinystr",
+ "unic-langid-impl",
+ "unic-langid-macros-impl",
+]
+
+[[package]]
+name = "unic-langid-macros-impl"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0098f77bd754f8fb7850cdf4ab143aa821898c4ac6dc16bcb2aa3e62ce858d1"
+dependencies = [
+ "proc-macro-hack",
+ "quote",
+ "syn",
+ "unic-langid-impl",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,6 +134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "bstr"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -162,6 +168,7 @@ dependencies = [
  "indoc",
  "itertools",
  "lazy_static",
+ "locale_config",
  "maplit",
  "nom 5.1.1",
  "num-traits",
@@ -175,6 +182,7 @@ dependencies = [
  "tracing-core",
  "tracing-subscriber",
  "unic-langid",
+ "unic-locale",
 ]
 
 [[package]]
@@ -881,12 +889,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "locale_config"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d2c35b16f4483f6c26f0e4e9550717a2f6575bcd6f12a53ff0c490a94a6934"
+dependencies = [
+ "lazy_static",
+ "objc",
+ "objc-foundation",
+ "regex",
+ "winapi",
+]
+
+[[package]]
 name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1005,6 +1035,35 @@ name = "obj"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c03f145738a183bf53d24b6d943c861fb045fe2c231c60832419fa0eb2c8e183"
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
+]
 
 [[package]]
 name = "once_cell"
@@ -1621,6 +1680,26 @@ dependencies = [
  "proc-macro-hack",
  "quote",
  "syn",
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-locale"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a0d6e6175e3f8e6d8ba39844a385724fd8b7f4218c783e671c43aaa43526c07"
+dependencies = [
+ "unic-langid-impl",
+ "unic-locale-impl",
+]
+
+[[package]]
+name = "unic-locale-impl"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe59350daadc2c23e7acec57cf47200187dbf3116819c9d5471d77384f789e93"
+dependencies = [
+ "tinystr",
  "unic-langid-impl",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,7 @@ dependencies = [
  "csv",
  "encoding_rs",
  "fluent",
+ "include_dir",
  "indexmap",
  "indoc",
  "itertools",
@@ -573,6 +574,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "failure"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8529c2421efa3066a5cbd8063d2244603824daccb6936b079010bb2aa89464b"
+dependencies = [
+ "backtrace",
+ "failure_derive",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030a733c8287d6213886dd487564ff5c8f6aae10278b3588ed177f9d18f8d231"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -711,6 +734,30 @@ name = "ident_case"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "include_dir"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ec8c61b6100ad0fc58ca644c59c0137d526d73cefa7497426369ea0d84d769"
+dependencies = [
+ "glob",
+ "include_dir_impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "include_dir_impl"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f03b4f7b64011df46794cc221854be5c3084345e260576518b91693866d0afd1"
+dependencies = [
+ "failure",
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "indexmap"
@@ -1345,6 +1392,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67656ea1dc1b41b1451851562ea232ec2e5a80242139f7e679ceccfb5d61f545"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,9 +8,9 @@ checksum = "5d2e7343e7fc9de883d1b0341e0b13970f764c14101234857d2ddafa1cb1cac2"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743ad5a418686aad3b87fd14c43badd828cf26e214a00f92a384291cf22e1811"
+checksum = "d5e63fd144e18ba274ae7095c0197a870a7b9468abc801dd62f190d80817d2ec"
 dependencies = [
  "memchr",
 ]
@@ -41,9 +41,9 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cf76cb6e2222ed0ea86b2b0ee2f71c96ec6edd5af42e84d59160e91b836ec4"
+checksum = "16971f2f0ce65c5cf2a1546cc6a0af102ecb11e265ddaa9433fb3e5bfdf676a4"
 
 [[package]]
 name = "arrayvec"
@@ -73,9 +73,9 @@ checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
 
 [[package]]
 name = "backtrace"
-version = "0.3.43"
+version = "0.3.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f80256bc78f67e7df7e36d77366f636ed976895d91fe2ab9efa3973e8fe8c4f"
+checksum = "ad235dabf00f36301792cfe82499880ba54c6486be094d1047b02bacb67c14e8"
 dependencies = [
  "backtrace-sys",
  "cfg-if",
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace-sys"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6575f128516de27e3ce99689419835fce9643a9b215a14d2b5b685be018491"
+checksum = "e17b52e737c40a7d75abca20b29a19a0eb7ba9fc72c5a72dd282a0a3c2c0dc35"
 dependencies = [
  "cc",
  "libc",
@@ -156,12 +156,13 @@ dependencies = [
  "crossbeam",
  "csv",
  "encoding_rs",
+ "fluent",
  "indexmap",
  "indoc",
  "itertools",
  "lazy_static",
  "maplit",
- "nom 5.1.0",
+ "nom 5.1.1",
  "num-traits",
  "obj",
  "serde",
@@ -171,6 +172,7 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-subscriber",
+ "unic-langid",
 ]
 
 [[package]]
@@ -278,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "cbindgen"
-version = "0.13.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e21019c4afc1dd5f5ab3ce212d8ccb953f43520db79e0bb6438f3e26cc57dccf"
+checksum = "2c955bd5e66e36a03612c877585d75219da64e3d9ae5f14d76c979ccb95de070"
 dependencies = [
  "clap",
  "log",
@@ -326,9 +328,9 @@ dependencies = [
 
 [[package]]
 name = "chardetng"
-version = "0.1.3"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19200261d1f12430abce7cafdafbf53ac92c502fbad8d015174883905d87a3bc"
+checksum = "293267de29bad310dc2cdf4a7d256de9ec27618e3a1a39a395a52ae7f1eef786"
 dependencies = [
  "encoding_rs",
  "memchr",
@@ -494,9 +496,9 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.6"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b5cadb6b25c77aeff80ba701712494213f4a8418fcda2ee11b6560c3ad0bf4c"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
 dependencies = [
  "memchr",
 ]
@@ -595,10 +597,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7720e3feab35a8aacf3927bf0aea2fe9bd59bde9cd396faf5c01ddaa12c258b"
+dependencies = [
+ "fluent-bundle",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-bundle"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc7bdf8a047142c86627fed5789fda5ffad8ce549e4fc8b8b3bcd08710a1e7"
+dependencies = [
+ "fluent-langneg",
+ "fluent-syntax",
+ "intl-memoizer",
+ "intl_pluralrules",
+ "rental",
+ "smallvec",
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-langneg"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe5815efd5542e40841cd34ef9003822352b04c67a70c595c6758597c72e1f56"
+dependencies = [
+ "unic-langid",
+]
+
+[[package]]
+name = "fluent-syntax"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac0f7e83d14cccbf26e165d8881dcac5891af0d85a88543c09dd72ebd31d91ba"
+
+[[package]]
 name = "fnv"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
+
+[[package]]
+name = "fxhash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "getrandom"
@@ -628,18 +679,18 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eff2656d88f158ce120947499e971d743c05dbcbed62e5bd2f38f1698bbc3772"
+checksum = "1010591b26bbfe835e9faeabeb11866061cc7dcebffd56ad7d0942d0e61aefd8"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "honggfuzz"
-version = "0.5.45"
+version = "0.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24c27b4aa3049d6d10d8e33d52c9d03ca9aec18f8a449b246f8c4a5b0c10fb34"
+checksum = "c3de2c3273ef7735df1c5a72128ca85b1d20105b9aac643cdfd7a6e581311150"
 dependencies = [
  "arbitrary",
  "lazy_static",
@@ -706,6 +757,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "intl-memoizer"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff533e7939a956a8b4f328b498b3ac59ee4259f9aaede10a58c28cbeb59e1c0d"
+dependencies = [
+ "type-map",
+ "unic-langid",
+]
+
+[[package]]
+name = "intl_pluralrules"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d82c14d8eece42c03353e0ce86a4d3f97b1f1cef401e4d962dca6c6214a85002"
+dependencies = [
+ "tinystr",
+ "unic-langid",
+]
+
+[[package]]
 name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -734,9 +805,9 @@ checksum = "b294d6fa9ee409a054354afc4352b0b9ef7ca222c69b8812cbea9e7d2bf3783f"
 
 [[package]]
 name = "lexical-core"
-version = "0.4.6"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304bccb228c4b020f3a4835d247df0a02a7c4686098d4167762cfbbe4c5cb14"
+checksum = "d7043aa5c05dd34fb73b47acb8c3708eac428de4545ea3682ed2f11293ebd890"
 dependencies = [
  "arrayvec",
  "cfg-if",
@@ -747,9 +818,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.66"
+version = "0.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d515b1f41455adea1313a4a2ac8a8a477634fbae63cc6100e3aebb207ce61558"
+checksum = "eb147597cdf94ed43ab7a9038716637d2d1bf2bc571da995d0028dec06bd3018"
 
 [[package]]
 name = "libloading"
@@ -787,12 +858,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.0"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3197e20c7edb283f87c071ddfc7a2cca8f8e0b888c242959846a6fce03c72223"
-dependencies = [
- "libc",
-]
+checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "memmap"
@@ -835,18 +903,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ad2a91a8e869eeb30b9cb3119ae87773a8f4ae617f41b1eb9c154b2905f7bd6"
 dependencies = [
  "memchr",
- "version_check",
+ "version_check 0.1.5",
 ]
 
 [[package]]
 name = "nom"
-version = "5.1.0"
+version = "5.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c433f4d505fe6ce7ff78523d2fa13a0b9f2690e181fc26168bcbe5ccc5d14e07"
+checksum = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
 dependencies = [
  "lexical-core",
  "memchr",
- "version_check",
+ "version_check 0.9.1",
 ]
 
 [[package]]
@@ -904,28 +972,28 @@ checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
 
 [[package]]
 name = "proc-macro-error"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875077759af22fa20b610ad4471d8155b321c89c3f2785526c9839b099be4e0a"
+checksum = "e7959c6467d962050d639361f7703b2051c43036d03493c36f01d440fdd3138a"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
+ "version_check 0.9.1",
 ]
 
 [[package]]
 name = "proc-macro-error-attr"
-version = "0.4.8"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5717d9fa2664351a01ed73ba5ef6df09c01a521cb42cb65a061432a826f3c7a"
+checksum = "e4002d9f55991d5e019fb940a90e1a95eb80c24e77cb2462dd4dc869604d543a"
 dependencies = [
  "proc-macro2",
  "quote",
- "rustversion",
  "syn",
  "syn-mid",
+ "version_check 0.9.1",
 ]
 
 [[package]]
@@ -941,9 +1009,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acb317c6ff86a4e579dfa00fc5e6cca91ecbb4e7eb2df0468805b674eb88548"
+checksum = "6c09721c6781493a2a492a96b5a5bf19b65917fe6728884e7c44dd0c60ca3435"
 dependencies = [
  "unicode-xid",
 ]
@@ -956,9 +1024,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"
+checksum = "2bdc6c187c65bca4260c9011c9e3132efe4909da44726bad24cf7572ae338d7f"
 dependencies = [
  "proc-macro2",
 ]
@@ -1035,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.14"
+version = "0.6.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b28dfe3fe9badec5dbf0a79a9cccad2cfc2ab5484bdb3e44cbd1ae8b3ba2be06"
+checksum = "1132f845907680735a84409c3bebc64d1364a5683ffbce899550cd09d5eaefc1"
 
 [[package]]
 name = "remove_dir_all"
@@ -1046,6 +1114,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "rental"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8545debe98b2b139fb04cad8618b530e9b07c152d99a5de83c860b877d67847f"
+dependencies = [
+ "rental-impl",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "rental-impl"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "475e68978dc5b743f2f40d8e0a8fdc83f1c5e78cbf4b8fa5e74e73beebc340de"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1070,17 +1159,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3bba175698996010c4f6dce5e7f173b6eb781fce25d2cfc45e27091ce0b79f6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "ryu"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,9 +1175,9 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42e15e59b18a828bbf5c58ea01debb36b9b096346de35d941dcb89009f24a0d"
+checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sdl2-sys"
@@ -1151,9 +1229,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15913895b61e0be854afd32fd4163fcd2a3df34142cf2cb961b310ce694cbf90"
+checksum = "9371ade75d4c2d6cb154141b9752cf3781ec9c05e0e5cf35060e1e70ee7b9c25"
 dependencies = [
  "itoa",
  "ryu",
@@ -1200,6 +1278,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c2fb2ec9bcd216a5b0d0ccf31ab17b5ed1d627960edff65bbe95d3ce221cefc"
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+
+[[package]]
 name = "static_assertions"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1219,9 +1303,9 @@ checksum = "6446ced80d6c486436db5c078dde11a9f73d42b57fb273121e160b84f63d894c"
 
 [[package]]
 name = "structopt"
-version = "0.3.9"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1bcbed7d48956fcbb5d80c6b95aedb553513de0a1b451ea92679d999c010e98"
+checksum = "3fe43617218c0805c6eb37160119dc3c548110a67786da7218d1c6555212f073"
 dependencies = [
  "clap",
  "lazy_static",
@@ -1230,9 +1314,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.2"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "095064aa1f5b94d14e635d0a5684cf140c43ae40a0fd990708d38f5d669e5f64"
+checksum = "c6e79c80e0f4efd86ca960218d4e056249be189ff1c42824dcd9a7f51a56f0bd"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -1243,9 +1327,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.14"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af6f3550d8dff9ef7dc34d384ac6f107e5d31c8f57d9f28e0081503f547ac8f5"
+checksum = "123bd9499cfb380418d509322d7a6d52e5315f064fe4b3ad18a53d6b92c07859"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1337,6 +1421,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bac79c4b51eda1b090b1edebfb667821bbb51f713855164dc7cec2cb8ac2ba3"
+
+[[package]]
 name = "toml"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1347,9 +1437,9 @@ dependencies = [
 
 [[package]]
 name = "tracing"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e213bd24252abeb86a0b7060e02df677d367ce6cb772cef17e9214b8390a8d3"
+checksum = "1721cc8cf7d770cc4257872507180f35a4797272f5962f24c806af9e7faf52ab"
 dependencies = [
  "cfg-if",
  "tracing-attributes",
@@ -1358,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cfd395def5a60236e187e1ff905cb55668a59f29928dec05e6e1b1fd2ac1f3"
+checksum = "7fbad39da2f9af1cae3016339ad7f2c7a9e870f12e8fd04c4fd7ef35b30c0d2b"
 dependencies = [
  "quote",
  "syn",
@@ -1368,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13a46f11e372b8bd4b4398ea54353412fdd7fd42a8370c7e543e218cf7661978"
+checksum = "0aa83a9a47081cd522c09c81b31aec2c9273424976f922ad61c053b58350b715"
 dependencies = [
  "lazy_static",
 ]
@@ -1388,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-serde"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65dea8255e378ab7db9db2077a90cb3e051515e18eaa819a405c4eb129b9beb"
+checksum = "b6ccba2f8f16e0ed268fc765d9b7ff22e965e7185d32f8f1ec8294fe17d86e79"
 dependencies = [
  "serde",
  "tracing-core",
@@ -1398,9 +1488,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.0"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dc36e47794112347ccb9ae8a05b5ec4fab45f01545e4929323cdb1a543a8f4"
+checksum = "dedebcf5813b02261d6bab3a12c6a8ae702580c0405a2e8ec16c3713caf14c20"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -1414,6 +1504,33 @@ dependencies = [
  "tracing-core",
  "tracing-log",
  "tracing-serde",
+]
+
+[[package]]
+name = "type-map"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d2741b1474c327d95c1f1e3b0a2c3977c8e128409c572a33af2914e7d636717"
+dependencies = [
+ "fxhash",
+]
+
+[[package]]
+name = "unic-langid"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d81136159f779c35b10655f45210c71cd5ca5a45aadfe9840a61c7071735ed"
+dependencies = [
+ "unic-langid-impl",
+]
+
+[[package]]
+name = "unic-langid-impl"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43c61e94492eb67f20facc7b025778a904de83d953d8fcb60dd9adfd6e2d0ea"
+dependencies = [
+ "tinystr",
 ]
 
 [[package]]
@@ -1468,6 +1585,12 @@ name = "version_check"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
+
+[[package]]
+name = "version_check"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "078775d0255232fb988e6fccf26ddc9d1ac274299aaedcedce21c6f72cc533ce"
 
 [[package]]
 name = "walkdir"

--- a/bve-derive/src/kvp.rs
+++ b/bve-derive/src/kvp.rs
@@ -373,8 +373,9 @@ pub fn kvp_section(item: TokenStream) -> TokenStream {
                         // We have more bare fields than we have places to put them, complain
                         crate::parse::kvp::ValueData::Value{ .. } => warnings.push(crate::parse::kvp::KVPGenericWarning{
                             span: field.span,
-                            kind: crate::parse::kvp::KVPGenericWarningKind::UnknownField {
-                                name: format!("<bare field {} greater than {} field count>", bare_counter + 1, #bare_field_counter),
+                            kind: crate::parse::kvp::KVPGenericWarningKind::TooManyFields {
+                                idx: bare_counter,
+                                max: #bare_field_counter,
                             }
                         }),
                     }

--- a/bve/Cargo.toml
+++ b/bve/Cargo.toml
@@ -26,6 +26,7 @@ include_dir = "0.5.0"
 indexmap = "1.2"
 itertools = "0.8"
 lazy_static = "1.4.0"
+locale_config = "0.3.0"
 nom = "5.1.0"
 num-traits = "0.2.11"
 once_cell = "1.3.1"
@@ -35,6 +36,7 @@ serde_plain = "0.3"
 tracing = "0.1.12"
 tracing-core = "0.1.9"
 unic-langid = { version = "0.8.0", features = ["unic-langid-macros"] }
+unic-locale = "0.8.0"
 
 [dev-dependencies]
 indoc = "0.3.4"

--- a/bve/Cargo.toml
+++ b/bve/Cargo.toml
@@ -28,12 +28,13 @@ itertools = "0.8"
 lazy_static = "1.4.0"
 nom = "5.1.0"
 num-traits = "0.2.11"
+once_cell = "1.3.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.45"
 serde_plain = "0.3"
 tracing = "0.1.12"
 tracing-core = "0.1.9"
-unic-langid = "0.8.0"
+unic-langid = { version = "0.8.0", features = ["unic-langid-macros"] }
 
 [dev-dependencies]
 indoc = "0.3.4"

--- a/bve/Cargo.toml
+++ b/bve/Cargo.toml
@@ -22,6 +22,7 @@ crossbeam = "0.7.3"
 csv = { version = "1.1" }
 encoding_rs = "0.8.22"
 fluent = "0.10.2"
+include_dir = "0.5.0"
 indexmap = "1.2"
 itertools = "0.8"
 lazy_static = "1.4.0"

--- a/bve/Cargo.toml
+++ b/bve/Cargo.toml
@@ -21,6 +21,7 @@ chardetng = "0.1.3"
 crossbeam = "0.7.3"
 csv = { version = "1.1" }
 encoding_rs = "0.8.22"
+fluent = "0.10.2"
 indexmap = "1.2"
 itertools = "0.8"
 lazy_static = "1.4.0"
@@ -31,6 +32,7 @@ serde_json = "1.0.45"
 serde_plain = "0.3"
 tracing = "0.1.12"
 tracing-core = "0.1.9"
+unic-langid = "0.8.0"
 
 [dev-dependencies]
 indoc = "0.3.4"

--- a/bve/data/l10n/de/main.ftl
+++ b/bve/data/l10n/de/main.ftl
@@ -1,3 +1,5 @@
 name = BVE-Reborn
 
-langauge-code = de
+language-code = de
+
+welcome = Willkommen bei {name} mit der Sprache "{language-code}", {$name}

--- a/bve/data/l10n/de/main.ftl
+++ b/bve/data/l10n/de/main.ftl
@@ -1,0 +1,3 @@
+name = BVE-Reborn
+
+langauge-code = de

--- a/bve/data/l10n/en/main.ftl
+++ b/bve/data/l10n/en/main.ftl
@@ -1,3 +1,5 @@
 name = BVE-Reborn
 
-langauge-code = en
+language-code = en
+
+welcome = Welcome to {name} with the language "{language-code}", {$name}

--- a/bve/data/l10n/en/main.ftl
+++ b/bve/data/l10n/en/main.ftl
@@ -1,0 +1,3 @@
+name = BVE-Reborn
+
+langauge-code = en

--- a/bve/src/data.rs
+++ b/bve/src/data.rs
@@ -1,0 +1,3 @@
+use include_dir::Dir;
+
+pub const DATA: Dir<'static> = include_dir::include_dir!("data");

--- a/bve/src/l10n/current.rs
+++ b/bve/src/l10n/current.rs
@@ -7,18 +7,18 @@ pub fn get_current_language() -> Language {
 
     // Look for the message language
     if let Some((_category, range)) = locale.tags().find(|(c, _)| *c == Some("messages")) {
-        parse_language_range(range)
+        parse_language_range(&range)
     } else {
         // If it's not there, just grab the first one.
         if let Some((_category, range)) = locale.tags().next() {
-            parse_language_range(range)
+            parse_language_range(&range)
         } else {
             Language::EN
         }
     }
 }
 
-fn parse_language_range(range: LanguageRange<'_>) -> Language {
+fn parse_language_range(range: &LanguageRange<'_>) -> Language {
     let range_str = range.to_string();
 
     if range_str.is_empty() {
@@ -27,8 +27,5 @@ fn parse_language_range(range: LanguageRange<'_>) -> Language {
 
     let locale = unic_locale::Locale::from_bytes(range_str.as_bytes()).expect("Unable to parse locale");
 
-    match locale.langid.language() {
-        "de" => Language::DE,
-        "en" | _ => Language::EN,
-    }
+    Language::from_code(locale.langid.language())
 }

--- a/bve/src/l10n/current.rs
+++ b/bve/src/l10n/current.rs
@@ -1,8 +1,8 @@
-use crate::l10n::Language;
+use crate::l10n::{BVELanguage, BVELocale};
 use locale_config::LanguageRange;
 
 #[must_use]
-pub fn get_current_language() -> Language {
+pub fn get_current_language() -> BVELocale {
     let locale = locale_config::Locale::user_default();
 
     // Look for the message language
@@ -13,19 +13,19 @@ pub fn get_current_language() -> Language {
         if let Some((_category, range)) = locale.tags().next() {
             parse_language_range(&range)
         } else {
-            Language::EN
+            BVELocale::from_language(BVELanguage::EN)
         }
     }
 }
 
-fn parse_language_range(range: &LanguageRange<'_>) -> Language {
+fn parse_language_range(range: &LanguageRange<'_>) -> BVELocale {
     let range_str = range.to_string();
 
     if range_str.is_empty() {
-        return Language::EN;
+        return BVELocale::from_language(BVELanguage::EN);
     }
 
     let locale = unic_locale::Locale::from_bytes(range_str.as_bytes()).expect("Unable to parse locale");
 
-    Language::from_code(locale.langid.language())
+    BVELocale::from_ident(locale.langid)
 }

--- a/bve/src/l10n/current.rs
+++ b/bve/src/l10n/current.rs
@@ -1,0 +1,34 @@
+use crate::l10n::Language;
+use locale_config::LanguageRange;
+
+#[must_use]
+pub fn get_current_language() -> Language {
+    let locale = locale_config::Locale::user_default();
+
+    // Look for the message language
+    if let Some((_category, range)) = locale.tags().find(|(c, _)| *c == Some("messages")) {
+        parse_language_range(range)
+    } else {
+        // If it's not there, just grab the first one.
+        if let Some((_category, range)) = locale.tags().next() {
+            parse_language_range(range)
+        } else {
+            Language::EN
+        }
+    }
+}
+
+fn parse_language_range(range: LanguageRange<'_>) -> Language {
+    let range_str = range.to_string();
+
+    if range_str.is_empty() {
+        return Language::EN;
+    }
+
+    let locale = unic_locale::Locale::from_bytes(range_str.as_bytes()).expect("Unable to parse locale");
+
+    match locale.langid.language() {
+        "de" => Language::DE,
+        "en" | _ => Language::EN,
+    }
+}

--- a/bve/src/l10n/load.rs
+++ b/bve/src/l10n/load.rs
@@ -1,0 +1,41 @@
+use crate::data::DATA;
+use crate::l10n::{BVELocale, Language};
+use fluent::{FluentBundle, FluentResource};
+use include_dir::File;
+
+#[must_use]
+pub fn load_locale(language: Language) -> BVELocale {
+    let mut bundle = FluentBundle::new(&[language.get_identifier(), Language::EN.get_identifier()]);
+
+    // First load english as a baseline
+    for x in load_resources(Language::EN) {
+        bundle.add_resource(x).expect("Failed to add FTL resources to bundle")
+    }
+
+    // Then load other language
+    if language != Language::EN {
+        for x in load_resources(language) {
+            bundle.add_resource_overriding(x);
+        }
+    }
+
+    BVELocale { language, bundle }
+}
+
+#[must_use]
+fn load_resources(language: Language) -> impl Iterator<Item = FluentResource> {
+    enumerate_language_files(language).iter().map(|file| {
+        FluentResource::try_new(String::from(
+            file.contents_utf8()
+                .unwrap_or_else(|| panic!("Translation file {} is not utf-8", file.path().display())),
+        ))
+        .unwrap_or_else(|_| panic!("Translation file {} is not valid ftl", file.path().display()))
+    })
+}
+
+#[must_use]
+pub fn enumerate_language_files(language: Language) -> &'static [File<'static>] {
+    DATA.get_dir(format!("l10n/{}", language))
+        .unwrap_or_else(|| panic!("Missing language dir {}", language))
+        .files()
+}

--- a/bve/src/l10n/load.rs
+++ b/bve/src/l10n/load.rs
@@ -22,7 +22,6 @@ pub fn load_locale(language: Language) -> BVELocale {
     BVELocale { language, bundle }
 }
 
-#[must_use]
 fn load_resources(language: Language) -> impl Iterator<Item = FluentResource> {
     enumerate_language_files(language).iter().map(|file| {
         FluentResource::try_new(String::from(

--- a/bve/src/l10n/mod.rs
+++ b/bve/src/l10n/mod.rs
@@ -1,17 +1,19 @@
 use crate::data::DATA;
-use fluent::{FluentBundle, FluentResource};
+use fluent::{FluentBundle, FluentResource, FluentValue};
 use include_dir::File;
+use locale_config::LanguageRange;
+use nom::lib::std::collections::HashMap;
 use once_cell::sync::Lazy;
 use std::fmt;
 use std::fmt::{Display, Formatter};
-use std::sync::Mutex;
+use std::sync::RwLock;
 use unic_langid::{langid, LanguageIdentifier};
 
-pub static CURRENT_BVE_LOCALE: Lazy<Mutex<BVELocale>> = Lazy::new(|| Mutex::new(load_locale(Language::EN)));
+pub static CURRENT_BVE_LOCALE: Lazy<RwLock<BVELocale>> = Lazy::new(|| RwLock::new(load_locale(get_current_language())));
 
 pub struct BVELocale {
     language: Language,
-    strings: FluentBundle<FluentResource>,
+    bundle: FluentBundle<FluentResource>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -33,14 +35,80 @@ impl Language {
 impl Display for Language {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            Self::EN => write!(f, "us"),
+            Self::EN => write!(f, "en"),
             Self::DE => write!(f, "de"),
         }
     }
 }
 
+#[must_use]
+pub fn get_current_language() -> Language {
+    let locale = locale_config::Locale::user_default();
+
+    // Look for the message language
+    if let Some((_category, range)) = locale.tags().find(|(c, _)| *c == Some("messages")) {
+        parse_language_range(range)
+    } else {
+        // If it's not there, just grab the first one.
+        if let Some((_category, range)) = locale.tags().next() {
+            parse_language_range(range)
+        } else {
+            Language::EN
+        }
+    }
+}
+
+fn parse_language_range(range: LanguageRange<'_>) -> Language {
+    let range_str = range.to_string();
+
+    let locale = unic_locale::Locale::from_bytes(range_str.as_bytes()).expect("Unable to parse locale");
+
+    match locale.langid.language() {
+        "de" => Language::DE,
+        "en" | _ => Language::EN,
+    }
+}
+
+#[test]
+fn t() {
+    let l = CURRENT_BVE_LOCALE.read().expect("Unable to lock LocaleMutex");
+    let msg = l.bundle.get_message("welcome").expect("Missing translation name");
+    let pattern = msg.value.expect("Message has no pattern");
+    let mut errors = vec![];
+    let mut args = HashMap::new();
+    args.insert("name", FluentValue::from("Connor"));
+    let value = l.bundle.format_pattern(&pattern, Some(&args), &mut errors);
+    println!("{}", value);
+}
+
+#[must_use]
 pub fn load_locale(language: Language) -> BVELocale {
-    unimplemented!()
+    let mut bundle = FluentBundle::new(&[language.get_identifier(), Language::EN.get_identifier()]);
+
+    // First load english as a baseline
+    for x in load_resources(Language::EN) {
+        bundle.add_resource(x).expect("Failed to add FTL resources to bundle")
+    }
+
+    // Then load other language
+    if language != Language::EN {
+        for x in load_resources(language) {
+            bundle.add_resource_overriding(x);
+        }
+    }
+
+    BVELocale { language, bundle }
+}
+
+#[must_use]
+fn load_resources(language: Language) -> impl Iterator<Item = FluentResource> {
+    enumerate_language_files(language).iter().map(|file| {
+        FluentResource::try_new(String::from(
+            file.contents_utf8()
+                .unwrap_or_else(|| panic!("Translation file {} is not utf-8", file.path().display())),
+        ))
+        .unwrap_or_else(|_| panic!("Translation file {} is not valid ftl", file.path().display()))
+    })
 }
 
 #[must_use]

--- a/bve/src/l10n/mod.rs
+++ b/bve/src/l10n/mod.rs
@@ -25,6 +25,13 @@ pub enum Language {
 }
 
 impl Language {
+    pub fn from_code(code: &str) -> Self {
+        match code {
+            "de" => Self::DE,
+            _ => Self::EN,
+        }
+    }
+
     #[must_use]
     pub fn get_identifier(self) -> LanguageIdentifier {
         match self {

--- a/bve/src/l10n/mod.rs
+++ b/bve/src/l10n/mod.rs
@@ -1,0 +1,51 @@
+use crate::data::DATA;
+use fluent::{FluentBundle, FluentResource};
+use include_dir::File;
+use once_cell::sync::Lazy;
+use std::fmt;
+use std::fmt::{Display, Formatter};
+use std::sync::Mutex;
+use unic_langid::{langid, LanguageIdentifier};
+
+pub static CURRENT_BVE_LOCALE: Lazy<Mutex<BVELocale>> = Lazy::new(|| Mutex::new(load_locale(Language::EN)));
+
+pub struct BVELocale {
+    language: Language,
+    strings: FluentBundle<FluentResource>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum Language {
+    EN,
+    DE,
+}
+
+impl Language {
+    #[must_use]
+    pub fn get_identifier(self) -> LanguageIdentifier {
+        match self {
+            Self::EN => langid!("en-US"),
+            Self::DE => langid!("de-DE"),
+        }
+    }
+}
+
+impl Display for Language {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EN => write!(f, "us"),
+            Self::DE => write!(f, "de"),
+        }
+    }
+}
+
+pub fn load_locale(language: Language) -> BVELocale {
+    unimplemented!()
+}
+
+#[must_use]
+pub fn enumerate_language_files(language: Language) -> &'static [File<'static>] {
+    DATA.get_dir(format!("l10n/{}", language))
+        .unwrap_or_else(|| panic!("Missing language dir {}", language))
+        .files()
+}

--- a/bve/src/l10n/mod.rs
+++ b/bve/src/l10n/mod.rs
@@ -1,19 +1,20 @@
-use crate::data::DATA;
-use fluent::{FluentBundle, FluentResource, FluentValue};
-use include_dir::File;
-use locale_config::LanguageRange;
-use nom::lib::std::collections::HashMap;
+pub use current::*;
+use fluent::{FluentBundle, FluentResource};
+pub use load::*;
 use once_cell::sync::Lazy;
 use std::fmt;
 use std::fmt::{Display, Formatter};
 use std::sync::RwLock;
 use unic_langid::{langid, LanguageIdentifier};
 
+mod current;
+mod load;
+
 pub static CURRENT_BVE_LOCALE: Lazy<RwLock<BVELocale>> = Lazy::new(|| RwLock::new(load_locale(get_current_language())));
 
 pub struct BVELocale {
-    language: Language,
-    bundle: FluentBundle<FluentResource>,
+    pub language: Language,
+    pub bundle: FluentBundle<FluentResource>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -41,83 +42,61 @@ impl Display for Language {
     }
 }
 
-#[must_use]
-pub fn get_current_language() -> Language {
-    let locale = locale_config::Locale::user_default();
-
-    // Look for the message language
-    if let Some((_category, range)) = locale.tags().find(|(c, _)| *c == Some("messages")) {
-        parse_language_range(range)
-    } else {
-        // If it's not there, just grab the first one.
-        if let Some((_category, range)) = locale.tags().next() {
-            parse_language_range(range)
-        } else {
-            Language::EN
-        }
-    }
+macro_rules! localize {
+    ($name:literal, $($key:literal -> $value:literal),+ $(,)*) => {
+        localize!(crate::l10n::CURRENT_BVE_LOCALE.read().expect("Unable to lock LocaleMutex"), $name, $($key -> $value),+)
+    };
+    ($name:literal) => {
+        localize!(crate::l10n::CURRENT_BVE_LOCALE.read().expect("Unable to lock LocaleMutex"), $name)
+    };
+    ($locale:expr, $name:literal, $($key:literal -> $value:literal),+ $(,)*) => {{
+        let mut errors = std::vec::Vec::new();
+        let mut args = std::collections::HashMap::new();
+        $(
+            args.insert($key, fluent::FluentValue::from($value));
+        )*
+        let guard = $locale;
+        let msg = guard.bundle.get_message($name).expect("Missing translation name");
+        let pattern = msg.value.expect("Message has no pattern");
+        let formatted: std::string::String = guard.bundle.format_pattern(&pattern, Some(&args), &mut errors).to_string();
+        assert_eq!(errors, std::vec::Vec::new());
+        formatted
+    }};
+    ($locale:expr, $name:literal) => {{
+        let mut errors = std::vec::Vec::new();
+        let guard = $locale;
+        let msg = guard.bundle.get_message($name).expect("Missing translation name");
+        let pattern = msg.value.expect("Message has no pattern");
+        let formatted: std::string::String = guard.bundle.format_pattern(&pattern, None, &mut errors).to_string();
+        assert_eq!(errors, std::vec::Vec::new());
+        formatted
+    }};
 }
 
-fn parse_language_range(range: LanguageRange<'_>) -> Language {
-    let range_str = range.to_string();
+#[cfg(test)]
+mod test {
+    use crate::l10n::{load_locale, Language};
 
-    if range_str.is_empty() {
-        return Language::EN;
+    macro_rules! loc_test {
+        ($($tokens:tt)*) => {{
+            let result = localize!($($tokens)*);
+            assert!(!result.is_empty());
+        }};
     }
 
-    let locale = unic_locale::Locale::from_bytes(range_str.as_bytes()).expect("Unable to parse locale");
-
-    match locale.langid.language() {
-        "de" => Language::DE,
-        "en" | _ => Language::EN,
-    }
-}
-
-#[test]
-fn t() {
-    let l = CURRENT_BVE_LOCALE.read().expect("Unable to lock LocaleMutex");
-    let msg = l.bundle.get_message("welcome").expect("Missing translation name");
-    let pattern = msg.value.expect("Message has no pattern");
-    let mut errors = vec![];
-    let mut args = HashMap::new();
-    args.insert("name", FluentValue::from("Connor"));
-    let value = l.bundle.format_pattern(&pattern, Some(&args), &mut errors);
-    println!("{}", value);
-}
-
-#[must_use]
-pub fn load_locale(language: Language) -> BVELocale {
-    let mut bundle = FluentBundle::new(&[language.get_identifier(), Language::EN.get_identifier()]);
-
-    // First load english as a baseline
-    for x in load_resources(Language::EN) {
-        bundle.add_resource(x).expect("Failed to add FTL resources to bundle")
+    macro_rules! language_test {
+        ($name:ident, $lang:ident) => {
+            #[test]
+            fn $name() {
+                let language_value = load_locale(Language::$lang);
+                let language = &language_value;
+                loc_test!(language, "name");
+                loc_test!(language, "language-code");
+                loc_test!(language, "welcome", "name" -> "MyUsername");
+            }
+        };
     }
 
-    // Then load other language
-    if language != Language::EN {
-        for x in load_resources(language) {
-            bundle.add_resource_overriding(x);
-        }
-    }
-
-    BVELocale { language, bundle }
-}
-
-#[must_use]
-fn load_resources(language: Language) -> impl Iterator<Item = FluentResource> {
-    enumerate_language_files(language).iter().map(|file| {
-        FluentResource::try_new(String::from(
-            file.contents_utf8()
-                .unwrap_or_else(|| panic!("Translation file {} is not utf-8", file.path().display())),
-        ))
-        .unwrap_or_else(|_| panic!("Translation file {} is not valid ftl", file.path().display()))
-    })
-}
-
-#[must_use]
-pub fn enumerate_language_files(language: Language) -> &'static [File<'static>] {
-    DATA.get_dir(format!("l10n/{}", language))
-        .unwrap_or_else(|| panic!("Missing language dir {}", language))
-        .files()
+    language_test!(en, EN);
+    language_test!(de, DE);
 }

--- a/bve/src/l10n/mod.rs
+++ b/bve/src/l10n/mod.rs
@@ -61,6 +61,10 @@ pub fn get_current_language() -> Language {
 fn parse_language_range(range: LanguageRange<'_>) -> Language {
     let range_str = range.to_string();
 
+    if range_str.is_empty() {
+        return Language::EN;
+    }
+
     let locale = unic_locale::Locale::from_bytes(range_str.as_bytes()).expect("Unable to parse locale");
 
     match locale.langid.language() {

--- a/bve/src/l10n/mod.rs
+++ b/bve/src/l10n/mod.rs
@@ -42,12 +42,13 @@ impl Display for Language {
     }
 }
 
+#[macro_export]
 macro_rules! localize {
     ($name:literal, $($key:literal -> $value:literal),+ $(,)*) => {
-        localize!(crate::l10n::CURRENT_BVE_LOCALE.read().expect("Unable to lock LocaleMutex"), $name, $($key -> $value),+)
+        $crate::localize!($crate::l10n::CURRENT_BVE_LOCALE.read().expect("Unable to lock LocaleMutex"), $name, $($key -> $value),+)
     };
     ($name:literal) => {
-        localize!(crate::l10n::CURRENT_BVE_LOCALE.read().expect("Unable to lock LocaleMutex"), $name)
+        $crate::localize!($crate::l10n::CURRENT_BVE_LOCALE.read().expect("Unable to lock LocaleMutex"), $name)
     };
     ($locale:expr, $name:literal, $($key:literal -> $value:literal),+ $(,)*) => {{
         let mut errors = std::vec::Vec::new();

--- a/bve/src/l10n/mod.rs
+++ b/bve/src/l10n/mod.rs
@@ -11,6 +11,7 @@ mod current;
 mod load;
 
 pub static CURRENT_BVE_LOCALE: Lazy<RwLock<BVELocale>> = Lazy::new(|| RwLock::new(load_locale(get_current_language())));
+pub static ENGLISH_LOCALE: Lazy<BVELocale> = Lazy::new(|| load_locale(Language::EN));
 
 pub struct BVELocale {
     pub language: Language,
@@ -44,19 +45,28 @@ impl Display for Language {
 
 #[macro_export]
 macro_rules! localize {
+    // Localize in english for logging
+    (@en $name:literal, $($key:literal -> $value:literal),+ $(,)*) => {
+        $crate::localize!($crate::l10n::ENGLISH_LOCALE, $name, $($key -> $value),+)
+    };
+    (@en $name:literal) => {
+        $crate::localize!($crate::l10n::ENGLISH_LOCALE, $name)
+    };
+    // Localize in the current locale
     ($name:literal, $($key:literal -> $value:literal),+ $(,)*) => {
         $crate::localize!($crate::l10n::CURRENT_BVE_LOCALE.read().expect("Unable to lock LocaleMutex"), $name, $($key -> $value),+)
     };
     ($name:literal) => {
         $crate::localize!($crate::l10n::CURRENT_BVE_LOCALE.read().expect("Unable to lock LocaleMutex"), $name)
     };
+    // Localize over the locale provided as first argument, taken by reference.
     ($locale:expr, $name:literal, $($key:literal -> $value:literal),+ $(,)*) => {{
         let mut errors = std::vec::Vec::new();
         let mut args = std::collections::HashMap::new();
         $(
             args.insert($key, fluent::FluentValue::from($value));
         )*
-        let guard = $locale;
+        let guard = &$locale;
         let msg = guard.bundle.get_message($name).expect("Missing translation name");
         let pattern = msg.value.expect("Message has no pattern");
         let formatted: std::string::String = guard.bundle.format_pattern(&pattern, Some(&args), &mut errors).to_string();
@@ -65,7 +75,7 @@ macro_rules! localize {
     }};
     ($locale:expr, $name:literal) => {{
         let mut errors = std::vec::Vec::new();
-        let guard = $locale;
+        let guard = &$locale;
         let msg = guard.bundle.get_message($name).expect("Missing translation name");
         let pattern = msg.value.expect("Message has no pattern");
         let formatted: std::string::String = guard.bundle.format_pattern(&pattern, None, &mut errors).to_string();
@@ -89,8 +99,7 @@ mod test {
         ($name:ident, $lang:ident) => {
             #[test]
             fn $name() {
-                let language_value = load_locale(Language::$lang);
-                let language = &language_value;
+                let language = load_locale(Language::$lang);
                 loc_test!(language, "name");
                 loc_test!(language, "language-code");
                 loc_test!(language, "welcome", "name" -> "MyUsername");

--- a/bve/src/lib.rs
+++ b/bve/src/lib.rs
@@ -47,13 +47,11 @@
 
 pub use datatypes::*;
 
-#[macro_use]
-pub mod l10n;
-
 pub mod concurrency;
 pub mod data;
 mod datatypes;
 pub mod filesystem;
 mod iter;
+pub mod l10n;
 pub mod log;
 pub mod parse;

--- a/bve/src/lib.rs
+++ b/bve/src/lib.rs
@@ -48,6 +48,7 @@
 pub use datatypes::*;
 
 pub mod concurrency;
+pub mod data;
 mod datatypes;
 pub mod filesystem;
 mod iter;

--- a/bve/src/lib.rs
+++ b/bve/src/lib.rs
@@ -52,5 +52,6 @@ pub mod data;
 mod datatypes;
 pub mod filesystem;
 mod iter;
+pub mod l10n;
 pub mod log;
 pub mod parse;

--- a/bve/src/lib.rs
+++ b/bve/src/lib.rs
@@ -47,11 +47,13 @@
 
 pub use datatypes::*;
 
+#[macro_use]
+pub mod l10n;
+
 pub mod concurrency;
 pub mod data;
 mod datatypes;
 pub mod filesystem;
 mod iter;
-pub mod l10n;
 pub mod log;
 pub mod parse;

--- a/bve/src/parse/kvp/tests/mod.rs
+++ b/bve/src/parse/kvp/tests/mod.rs
@@ -385,9 +385,7 @@ fn unknown_field() {
         warnings,
         vec![KVPGenericWarning {
             span: Span::from_line(1),
-            kind: KVPGenericWarningKind::UnknownField {
-                name: String::from("<bare field 1 greater than 0 field count>"),
-            }
+            kind: KVPGenericWarningKind::TooManyFields { idx: 0, max: 0 }
         }]
     );
 

--- a/bve/src/parse/kvp/traits.rs
+++ b/bve/src/parse/kvp/traits.rs
@@ -13,6 +13,7 @@ pub struct KVPGenericWarning {
 pub enum KVPGenericWarningKind {
     UnknownSection { name: String },
     UnknownField { name: String },
+    TooManyFields { idx: u64, max: u64 },
     InvalidValue { value: String },
 }
 

--- a/deny.toml
+++ b/deny.toml
@@ -14,6 +14,7 @@ allow = [
 [bans]
 multiple-versions = "deny"
 skip = [
+    { name = "version_check", version = "0.1.5" }, # Dependency of nom 4
     { name = "nom", version = "4" }, # cexpr is quite old and looking unmaintained
     { name = "strsim", version = "0.8.0" }, # clap 2 isn't in dev anymore, change merged with clap 3.
 ]


### PR DESCRIPTION
This adds all the machinery needed to use fluent for localization.

Notable features:
- `localize` macro that gets the localized string. Add `@en` to the beginning to force English locale for logging.
- Locale autodetection. Might only work best on windows as Linux's locale support isn't great.
- Localization tests which tests every string for every language.

This is not ready for translators yet, as the next step is actually building up the strings that are able to be translated.