### PR TITLE
Add panel.cfg parser

### DIFF
--- a/bve-corpus/src/bin/bve-parser-run.rs
+++ b/bve-corpus/src/bin/bve-parser-run.rs
@@ -3,6 +3,7 @@ use bve::parse::animated::parse_animated_file;
 use bve::parse::ats_cfg::parse_ats_cfg;
 use bve::parse::extensions_cfg::parse_extensions_cfg;
 use bve::parse::mesh::mesh_from_str;
+use bve::parse::panel1_cfg::parse_panel1_cfg;
 use bve::parse::train_dat::parse_train_dat;
 use clap::arg_enum;
 use std::path::{Path, PathBuf};
@@ -18,6 +19,7 @@ arg_enum! {
         Animated,
         TrainDat,
         ExtensionsCfg,
+        PanelCfg,
     }
 }
 
@@ -163,6 +165,29 @@ fn parse_config_ats_cfg(file: impl AsRef<Path>, options: &Options) {
     }
 }
 
+fn parse_config_panel1_cfg(file: impl AsRef<Path>, options: &Options) {
+    let contents = read_convert_utf8(file).expect("Must be able to read file");
+
+    let start = Instant::now();
+    let (parsed, warnings) = parse_panel1_cfg(&contents);
+    let duration = Instant::now() - start;
+
+    println!("Duration: {:.4}", duration.as_secs_f32());
+
+    if options.print_result {
+        println!("{:#?}", parsed);
+    }
+
+    if options.errors {
+        println!("Warnings:");
+        for e in &warnings {
+            println!("\t{} {:?}", e.span.line.map(|v| v as i64).unwrap_or(-1), e.kind)
+        }
+    } else {
+        println!("Warnings: {}", warnings.len());
+    }
+}
+
 fn main() {
     let options: Options = Options::from_args();
 
@@ -173,5 +198,6 @@ fn main() {
         FileType::Animated => parse_mesh_animated(&options.source_file, &options),
         FileType::TrainDat => parse_config_train_dat(&options.source_file, &options),
         FileType::ExtensionsCfg => parse_config_extensions_cfg(&options.source_file, &options),
+        FileType::PanelCfg => parse_config_panel1_cfg(&options.source_file, &options),
     }
 }

--- a/bve-corpus/src/worker/mod.rs
+++ b/bve-corpus/src/worker/mod.rs
@@ -6,6 +6,7 @@ use bve::parse::ats_cfg::parse_ats_cfg;
 use bve::parse::extensions_cfg::parse_extensions_cfg;
 use bve::parse::kvp::parse_kvp_file;
 use bve::parse::mesh::{mesh_from_str, FileType, MeshErrorKind, ParsedStaticObject};
+use bve::parse::panel1_cfg::parse_panel1_cfg;
 use bve::parse::train_dat::parse_train_dat;
 use core::panicking::panic;
 use crossbeam::atomic::AtomicCell;
@@ -136,6 +137,13 @@ fn processing_loop(
                 let (_parsed, warnings) = parse_extensions_cfg(&file_contents);
 
                 shared.extensions_cfg.finished.fetch_add(1, Ordering::AcqRel);
+
+                success_or_errors(warnings)
+            }
+            FileKind::PanelCfg => {
+                let (_parsed, warnings) = parse_panel1_cfg(&file_contents);
+
+                shared.panel_cfg.finished.fetch_add(1, Ordering::AcqRel);
 
                 success_or_errors(warnings)
             }

--- a/bve-derive/src/kvp.rs
+++ b/bve-derive/src/kvp.rs
@@ -19,8 +19,12 @@ fn split_aliases(input: String) -> Vec<String> {
     if input.is_empty() {
         vec![]
     } else {
-        input.split(';').map(str::trim).map(String::from).collect()
+        input.split(';').map(str::trim).map(str::to_lowercase).collect()
     }
+}
+
+fn lowercase(input: Option<String>) -> Option<String> {
+    input.map(|s| s.to_lowercase())
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -48,7 +52,7 @@ struct Field {
     bare: bool,
     #[darling(default)]
     variadic: bool,
-    #[darling(default)]
+    #[darling(map = "lowercase", default)]
     rename: Option<String>,
     #[darling(map = "split_aliases", default)]
     alias: Vec<String>,

--- a/bve-derive/src/kvp.rs
+++ b/bve-derive/src/kvp.rs
@@ -491,14 +491,14 @@ pub fn kvp_enum_numbers(item: TokenStream) -> TokenStream {
                 quote! {
                     #idx => Self::#ident,
                 },
-                if !variant.alias.is_empty() {
+                if variant.alias.is_empty() {
+                    TokenStream2::new()
+                } else {
                     let conditions =
                         combine_token_streams(variant.alias.iter().map(|s| quote! { #s }).intersperse(quote! {|}));
                     quote! {
                         #conditions => #idx,
                     }
-                } else {
-                    TokenStream2::new()
                 },
             )
         })

--- a/bve/src/parse/mod.rs
+++ b/bve/src/parse/mod.rs
@@ -6,6 +6,7 @@ pub mod extensions_cfg;
 pub mod function_scripts;
 pub mod kvp;
 pub mod mesh;
+pub mod panel1_cfg;
 pub mod train_dat;
 mod util;
 

--- a/bve/src/parse/panel1_cfg/mod.rs
+++ b/bve/src/parse/panel1_cfg/mod.rs
@@ -1,0 +1,3 @@
+pub use sections::*;
+
+mod sections;

--- a/bve/src/parse/panel1_cfg/mod.rs
+++ b/bve/src/parse/panel1_cfg/mod.rs
@@ -1,3 +1,13 @@
+use crate::parse::kvp::{parse_kvp_file, FromKVPFile, KVPGenericWarning, ANIMATED_LIKE};
+use crate::parse::util::strip_comments;
 pub use sections::*;
 
 mod sections;
+
+#[must_use]
+pub fn parse_panel1_cfg(input: &str) -> (ParsedPanel1Cfg, Vec<KVPGenericWarning>) {
+    let lower = strip_comments(input, ';').to_lowercase();
+    let kvp_file = parse_kvp_file(&lower, ANIMATED_LIKE);
+
+    ParsedPanel1Cfg::from_kvp_file(&kvp_file)
+}

--- a/bve/src/parse/panel1_cfg/sections/brake_indicator.rs
+++ b/bve/src/parse/panel1_cfg/sections/brake_indicator.rs
@@ -11,7 +11,7 @@ pub struct BrakeIndicatorSection {
 impl Default for BrakeIndicatorSection {
     fn default() -> Self {
         Self {
-            file: String::default(),
+            image: String::default(),
             corner: Vector2::from_value(0.0),
             width: 0.0,
         }

--- a/bve/src/parse/panel1_cfg/sections/brake_indicator.rs
+++ b/bve/src/parse/panel1_cfg/sections/brake_indicator.rs
@@ -1,0 +1,19 @@
+use bve_derive::FromKVPSection;
+use cgmath::{Array, Vector2};
+
+#[derive(Debug, Clone, PartialEq, FromKVPSection)]
+pub struct BrakeIndicatorSection {
+    pub file: String,
+    pub corner: Vector2<f32>,
+    pub width: f32,
+}
+
+impl Default for BrakeIndicatorSection {
+    fn default() -> Self {
+        Self {
+            file: String::default(),
+            corner: Vector2::from_value(0.0),
+            width: 0.0,
+        }
+    }
+}

--- a/bve/src/parse/panel1_cfg/sections/brake_indicator.rs
+++ b/bve/src/parse/panel1_cfg/sections/brake_indicator.rs
@@ -3,7 +3,7 @@ use cgmath::{Array, Vector2};
 
 #[derive(Debug, Clone, PartialEq, FromKVPSection)]
 pub struct BrakeIndicatorSection {
-    pub file: String,
+    pub image: String,
     pub corner: Vector2<f32>,
     pub width: f32,
 }

--- a/bve/src/parse/panel1_cfg/sections/digital_indicator.rs
+++ b/bve/src/parse/panel1_cfg/sections/digital_indicator.rs
@@ -23,9 +23,9 @@ impl Default for DigitalIndicatorSection {
 #[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
 pub enum Unit {
     #[kvp(default, alias = "km/h")]
-    Kph,
+    KilometersPerHour,
     #[kvp(alias = "mph")]
-    Mph,
+    MilesPerHour,
     #[kvp(alias = "m/s")]
-    Ms,
+    MetersPerSecond,
 }

--- a/bve/src/parse/panel1_cfg/sections/digital_indicator.rs
+++ b/bve/src/parse/panel1_cfg/sections/digital_indicator.rs
@@ -1,0 +1,31 @@
+use bve_derive::{FromKVPSection, FromKVPValueEnumNumbers};
+use cgmath::{Array, Vector2};
+
+#[derive(Debug, Clone, PartialEq, FromKVPSection)]
+pub struct DigitalIndicatorSection {
+    pub number: String,
+    pub corner: Vector2<f32>,
+    pub size: Vector2<f32>,
+    pub unit: Unit,
+}
+
+impl Default for DigitalIndicatorSection {
+    fn default() -> Self {
+        Self {
+            number: String::default(),
+            corner: Vector2::from_value(0.0),
+            size: Vector2::from_value(0.0),
+            unit: Unit::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
+pub enum Unit {
+    #[kvp(default, alias = "km/h")]
+    Kph,
+    #[kvp(alias = "mph")]
+    Mph,
+    #[kvp(alias = "m/s")]
+    Ms,
+}

--- a/bve/src/parse/panel1_cfg/sections/mod.rs
+++ b/bve/src/parse/panel1_cfg/sections/mod.rs
@@ -1,0 +1,35 @@
+use bve_derive::{FromKVPFile, FromKVPValueEnumNumbers};
+
+pub mod brake_indicator;
+pub mod digital_indicator;
+pub mod panel;
+pub mod pilot_lamp;
+pub mod pressure_indicator;
+pub mod speed_indicator;
+pub mod view;
+pub mod watch;
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPFile)]
+pub struct ParsedPanel1Cfg {
+    pub panel: panel::PanelSection,
+    pub view: view::ViewSection,
+    #[kvp(rename = "PressureIndicator", alias = "PressureGauge; PressureMeter; 圧力計")]
+    pub pressure_indicators: Vec<pressure_indicator::PressureIndicatorSection>,
+    #[kvp(rename = "SpeedIndicator", alias = "Speedometer; 速度計")]
+    pub speed_indicators: Vec<speed_indicator::SpeedIndicatorSection>,
+    #[kvp(rename = "DigitalIndicator")]
+    pub digital_indicators: Vec<digital_indicator::DigitalIndicatorSection>,
+    #[kvp(rename = "PilotLamp", alias = "知らせ灯")]
+    pub pilot_lamps: Vec<pilot_lamp::PilotLampSection>,
+    #[kvp(rename = "Watch", alias = "時計")]
+    pub watches: Vec<watch::WatchSection>,
+    #[kvp(rename = "BrakeIndicator", alias = "時計")]
+    pub brake_indicators: Vec<brake_indicator::BrakeIndicatorSection>,
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
+pub enum IndicatorType {
+    #[kvp(default)]
+    Gauge,
+    LED,
+}

--- a/bve/src/parse/panel1_cfg/sections/mod.rs
+++ b/bve/src/parse/panel1_cfg/sections/mod.rs
@@ -6,11 +6,14 @@ pub mod panel;
 pub mod pilot_lamp;
 pub mod pressure_indicator;
 pub mod speed_indicator;
+pub mod version;
 pub mod view;
 pub mod watch;
 
 #[derive(Debug, Default, Clone, PartialEq, FromKVPFile)]
 pub struct ParsedPanel1Cfg {
+    #[kvp(bare)]
+    pub version: version::VersionSection,
     pub panel: panel::PanelSection,
     pub view: view::ViewSection,
     #[kvp(rename = "PressureIndicator", alias = "PressureGauge; PressureMeter; 圧力計")]

--- a/bve/src/parse/panel1_cfg/sections/panel.rs
+++ b/bve/src/parse/panel1_cfg/sections/panel.rs
@@ -1,0 +1,6 @@
+use bve_derive::FromKVPSection;
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
+pub struct PanelSection {
+    pub background: String,
+}

--- a/bve/src/parse/panel1_cfg/sections/pilot_lamp.rs
+++ b/bve/src/parse/panel1_cfg/sections/pilot_lamp.rs
@@ -1,0 +1,22 @@
+use bve_derive::FromKVPSection;
+use cgmath::{Array, Vector2};
+
+#[derive(Debug, Clone, PartialEq, FromKVPSection)]
+pub struct PilotLampSection {
+    #[kvp(rename = "TurnOn", alias = "点灯")]
+    pub on: String,
+    #[kvp(rename = "TurnOff", alias = "消灯")]
+    pub off: String,
+    #[kvp(alias = "左上")]
+    pub corner: Vector2<f32>,
+}
+
+impl Default for PilotLampSection {
+    fn default() -> Self {
+        Self {
+            on: String::default(),
+            off: String::default(),
+            corner: Vector2::from_value(0.0),
+        }
+    }
+}

--- a/bve/src/parse/panel1_cfg/sections/pressure_indicator.rs
+++ b/bve/src/parse/panel1_cfg/sections/pressure_indicator.rs
@@ -1,5 +1,6 @@
+use crate::parse::kvp::FromKVPValue;
 use crate::parse::panel1_cfg::sections::IndicatorType;
-use bve_derive::{FromKVPSection, FromKVPValue, FromKVPValueEnumNumbers};
+use bve_derive::{FromKVPSection, FromKVPValueEnumNumbers};
 use cgmath::{Array, Vector2};
 
 #[derive(Debug, Clone, PartialEq, FromKVPSection)]
@@ -46,12 +47,24 @@ impl Default for PressureIndicatorSection {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, FromKVPValue)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct Needle {
     subject: Subject,
     red: u8,
     green: u8,
     blue: u8,
+}
+
+impl FromKVPValue for Needle {
+    fn from_kvp_value(value: &str) -> Option<Self> {
+        let mut iterator = value.split(",").flat_map(|v| v.split(":")).map(str::trim);
+        Some(Self {
+            subject: Subject::from_kvp_value(iterator.next()?)?,
+            red: u8::from_kvp_value(iterator.next()?)?,
+            green: u8::from_kvp_value(iterator.next()?)?,
+            blue: u8::from_kvp_value(iterator.next()?)?,
+        })
+    }
 }
 
 impl Default for Needle {

--- a/bve/src/parse/panel1_cfg/sections/pressure_indicator.rs
+++ b/bve/src/parse/panel1_cfg/sections/pressure_indicator.rs
@@ -49,10 +49,10 @@ impl Default for PressureIndicatorSection {
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct Needle {
-    subject: Subject,
-    red: u8,
-    green: u8,
-    blue: u8,
+    pub subject: Subject,
+    pub red: u8,
+    pub green: u8,
+    pub blue: u8,
 }
 
 impl FromKVPValue for Needle {

--- a/bve/src/parse/panel1_cfg/sections/pressure_indicator.rs
+++ b/bve/src/parse/panel1_cfg/sections/pressure_indicator.rs
@@ -30,7 +30,7 @@ pub struct PressureIndicatorSection {
 
 impl Default for PressureIndicatorSection {
     fn default() -> Self {
-        PressureIndicatorSection {
+        Self {
             indicator_type: IndicatorType::default(),
             lower_needle: Needle::default(),
             upper_needle: Needle::default(),

--- a/bve/src/parse/panel1_cfg/sections/pressure_indicator.rs
+++ b/bve/src/parse/panel1_cfg/sections/pressure_indicator.rs
@@ -1,0 +1,92 @@
+use crate::parse::panel1_cfg::sections::IndicatorType;
+use bve_derive::{FromKVPSection, FromKVPValue, FromKVPValueEnumNumbers};
+use cgmath::{Array, Vector2};
+
+#[derive(Debug, Clone, PartialEq, FromKVPSection)]
+pub struct PressureIndicatorSection {
+    #[kvp(rename = "type", alias = "形態")]
+    pub indicator_type: IndicatorType,
+    #[kvp(alias = "LowerHand; 下針")]
+    pub lower_needle: Needle,
+    #[kvp(alias = "UpperHand; 上針")]
+    pub upper_needle: Needle,
+    #[kvp(alias = "中心")]
+    pub center: Vector2<f32>,
+    #[kvp(alias = "半径")]
+    pub radius: f32,
+    #[kvp(alias = "背景")]
+    pub background: String,
+    #[kvp(alias = "ふた")]
+    pub cover: String,
+    #[kvp(alias = "単位")]
+    pub unit: Unit,
+    #[kvp(alias = "最小")]
+    pub minimum: f32,
+    #[kvp(alias = "最大")]
+    pub maximum: f32,
+    #[kvp(alias = "角度")]
+    pub angle: f32,
+}
+
+impl Default for PressureIndicatorSection {
+    fn default() -> Self {
+        PressureIndicatorSection {
+            indicator_type: IndicatorType::default(),
+            lower_needle: Needle::default(),
+            upper_needle: Needle::default(),
+            center: Vector2::from_value(0.0),
+            radius: 16.0,
+            background: String::default(),
+            cover: String::default(),
+            unit: Unit::default(),
+            minimum: 0.0,
+            maximum: 1000.0,
+            angle: 45.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValue)]
+pub struct Needle {
+    subject: Subject,
+    red: u8,
+    green: u8,
+    blue: u8,
+}
+
+impl Default for Needle {
+    fn default() -> Self {
+        Self {
+            subject: Subject::default(),
+            red: 255,
+            green: 255,
+            blue: 255,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
+pub enum Subject {
+    #[kvp(default)]
+    NoShow,
+    #[kvp(alias = "BC; ブレーキシリンダ")]
+    BrakeCylinder,
+    #[kvp(alias = "BP; ブレーキ管; 制動管")]
+    BrakePipe,
+    #[kvp(alias = "ER; 釣り合い空気溜め; 釣り合い空気ダメ; つりあい空気溜め; ツリアイ空気")]
+    EqualizingReservoir,
+    #[kvp(alias = "MR; 元空気溜め; 元空気ダメ")]
+    MainReservoir,
+    #[kvp(alias = "SAP; 直通管")]
+    StraightAirPipe,
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValueEnumNumbers)]
+pub enum Unit {
+    /// Kilo-pascal
+    #[kvp(default, alias = "kpa")]
+    Kpa,
+    /// Kilogram-force per centimeter squared (98066.5 Pa)
+    #[kvp(alias = "kgf/cm2; kgf/cm^2; kg/cm2; kg/cm^2")]
+    BrakeCylinder,
+}

--- a/bve/src/parse/panel1_cfg/sections/pressure_indicator.rs
+++ b/bve/src/parse/panel1_cfg/sections/pressure_indicator.rs
@@ -57,7 +57,7 @@ pub struct Needle {
 
 impl FromKVPValue for Needle {
     fn from_kvp_value(value: &str) -> Option<Self> {
-        let mut iterator = value.split(",").flat_map(|v| v.split(":")).map(str::trim);
+        let mut iterator = value.split(',').flat_map(|v| v.split(':')).map(str::trim);
         Some(Self {
             subject: Subject::from_kvp_value(iterator.next()?)?,
             red: u8::from_kvp_value(iterator.next()?)?,

--- a/bve/src/parse/panel1_cfg/sections/speed_indicator.rs
+++ b/bve/src/parse/panel1_cfg/sections/speed_indicator.rs
@@ -28,7 +28,7 @@ pub struct SpeedIndicatorSection {
 
 impl Default for SpeedIndicatorSection {
     fn default() -> Self {
-        SpeedIndicatorSection {
+        Self {
             indicator_type: IndicatorType::default(),
             center: Vector2::from_value(0.0),
             radius: 16.0,

--- a/bve/src/parse/panel1_cfg/sections/speed_indicator.rs
+++ b/bve/src/parse/panel1_cfg/sections/speed_indicator.rs
@@ -6,6 +6,8 @@ use cgmath::{Array, Vector2};
 pub struct SpeedIndicatorSection {
     #[kvp(rename = "type", alias = "形態")]
     pub indicator_type: IndicatorType,
+    #[kvp(alias = "Hand; 針")]
+    pub needle: Needle,
     #[kvp(alias = "中心")]
     pub center: Vector2<f32>,
     #[kvp(alias = "半径")]

--- a/bve/src/parse/panel1_cfg/sections/speed_indicator.rs
+++ b/bve/src/parse/panel1_cfg/sections/speed_indicator.rs
@@ -1,0 +1,61 @@
+use crate::parse::panel1_cfg::sections::IndicatorType;
+use bve_derive::{FromKVPSection, FromKVPValue};
+use cgmath::{Array, Vector2};
+
+#[derive(Debug, Clone, PartialEq, FromKVPSection)]
+pub struct SpeedIndicatorSection {
+    #[kvp(rename = "type", alias = "形態")]
+    pub indicator_type: IndicatorType,
+    #[kvp(alias = "中心")]
+    pub center: Vector2<f32>,
+    #[kvp(alias = "半径")]
+    pub radius: f32,
+    #[kvp(alias = "背景")]
+    pub background: String,
+    #[kvp(alias = "ふた")]
+    pub cover: String,
+    #[kvp(alias = "最小")]
+    pub minimum: f32,
+    #[kvp(alias = "最大")]
+    pub maximum: f32,
+    #[kvp(alias = "角度")]
+    pub angle: f32,
+    #[kvp(alias = "角度")]
+    pub atc: String,
+    #[kvp(alias = "Atc半径")]
+    pub atc_radius: f32,
+}
+
+impl Default for SpeedIndicatorSection {
+    fn default() -> Self {
+        SpeedIndicatorSection {
+            indicator_type: IndicatorType::default(),
+            center: Vector2::from_value(0.0),
+            radius: 16.0,
+            background: String::default(),
+            cover: String::default(),
+            minimum: 0.0,
+            maximum: 1000.0,
+            angle: 45.0,
+            atc: String::default(),
+            atc_radius: 0.0,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValue)]
+pub struct Needle {
+    pub red: u8,
+    pub green: u8,
+    pub blue: u8,
+}
+
+impl Default for Needle {
+    fn default() -> Self {
+        Self {
+            red: 255,
+            green: 255,
+            blue: 255,
+        }
+    }
+}

--- a/bve/src/parse/panel1_cfg/sections/speed_indicator.rs
+++ b/bve/src/parse/panel1_cfg/sections/speed_indicator.rs
@@ -32,6 +32,7 @@ impl Default for SpeedIndicatorSection {
     fn default() -> Self {
         Self {
             indicator_type: IndicatorType::default(),
+            needle: Needle::default(),
             center: Vector2::from_value(0.0),
             radius: 16.0,
             background: String::default(),

--- a/bve/src/parse/panel1_cfg/sections/version.rs
+++ b/bve/src/parse/panel1_cfg/sections/version.rs
@@ -1,0 +1,7 @@
+use bve_derive::FromKVPSection;
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
+pub struct VersionSection {
+    #[kvp(bare)]
+    pub version: String,
+}

--- a/bve/src/parse/panel1_cfg/sections/view.rs
+++ b/bve/src/parse/panel1_cfg/sections/view.rs
@@ -1,0 +1,7 @@
+use bve_derive::FromKVPSection;
+
+#[derive(Debug, Default, Clone, PartialEq, FromKVPSection)]
+pub struct ViewSection {
+    pub yaw: f32,
+    pub pitch: f32,
+}

--- a/bve/src/parse/panel1_cfg/sections/watch.rs
+++ b/bve/src/parse/panel1_cfg/sections/watch.rs
@@ -1,0 +1,42 @@
+use bve_derive::{FromKVPSection, FromKVPValue};
+use cgmath::{Array, Vector2};
+
+#[derive(Debug, Clone, PartialEq, FromKVPSection)]
+pub struct WatchSection {
+    #[kvp(alias = "背景")]
+    pub background: String,
+    #[kvp(alias = "中心")]
+    pub center: Vector2<f32>,
+    #[kvp(alias = "半径")]
+    pub radius: f32,
+    #[kvp(alias = "Hand; 針")]
+    pub needle: Needle,
+}
+
+impl Default for WatchSection {
+    fn default() -> Self {
+        Self {
+            background: String::default(),
+            center: Vector2::from_value(0.0),
+            radius: 16.0,
+            needle: Needle::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, FromKVPValue)]
+pub struct Needle {
+    pub red: u8,
+    pub green: u8,
+    pub blue: u8,
+}
+
+impl Default for Needle {
+    fn default() -> Self {
+        Self {
+            red: 255,
+            green: 255,
+            blue: 255,
+        }
+    }
+}


### PR DESCRIPTION
Welcome to the land of Japanese aliases. This adds the panel.cfg parser, known as `panel1` in a lot of the code to distinguish it from panel2.

Notable additional changes:
- Added aliasing to the `FromKVPValueEnumNumbers` macro.
- All KVP macros now lowercase all aliases so they can be written in source more naturally. This still needs to be fixed in the codebase.