### PR TITLE
Runtime Again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,13 +78,13 @@ jobs:
 
       - name: Build
         run: |
-          cargo build -Z unstable-options --profile lto -p bve-client -p bve-corpus
+          cargo build -Z unstable-options --profile lto -p bve-client -p bve-corpus -p bve-obj-conv
         shell: bash
 
       - name: Build
         run: |
           mkdir ${{ matrix.name }}
-          cp target/lto/bve-client${{ matrix.suffix }} target/lto/bve-corpus${{ matrix.suffix }} target/lto/bve-parser-run${{ matrix.suffix }} ${{ matrix.name }}
+          cp target/lto/bve-client${{ matrix.suffix }} target/lto/bve-corpus${{ matrix.suffix }} target/lto/bve-parser-run${{ matrix.suffix }} target/lto/bve-obj-conv${{ matrix.suffix }} ${{ matrix.name }}
         shell: bash
 
       - uses: actions/upload-artifact@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,7 @@ dependencies = [
  "chrono",
  "csv",
  "dashmap",
+ "derive_more",
  "encoding_rs",
  "fern",
  "fluent",
@@ -722,6 +723,17 @@ checksum = "e7e5d2a2273fed52a7f947ee55b092c4057025d7a3e04e5ecdbd25d6c3fb1bd7"
 dependencies = [
  "adler32",
  "byteorder",
+]
+
+[[package]]
+name = "derive_more"
+version = "0.99.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2323f3f47db9a0e77ce7a300605d8d2098597fc451ed1a97bb1f6411bb550a7"
+dependencies = [
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
+ "syn",
 ]
 
 [[package]]

--- a/bve-client/src/main.rs
+++ b/bve-client/src/main.rs
@@ -172,14 +172,11 @@ fn client_main() {
             for idx in 0..object.count {
                 runtime
                     .add_static_object(
-                        runtime::Location {
-                            chunk: runtime::ChunkAddress::new(0, 0),
-                            offset: runtime::ChunkOffset::new(
-                                f32::mul_add(object.offset_x, idx as f32, object.x),
-                                0.0,
-                                f32::mul_add(object.offset_z, idx as f32, object.z),
-                            ),
-                        },
+                        runtime::Location::from_absolute_position(Vector3::new(
+                            f32::mul_add(object.offset_x, idx as f32, object.x),
+                            0.0,
+                            f32::mul_add(object.offset_z, idx as f32, object.z),
+                        )),
                         PathBuf::from(object.path.clone()),
                     )
                     .await

--- a/bve-client/src/main.rs
+++ b/bve-client/src/main.rs
@@ -117,6 +117,18 @@ impl runtime::Client for Client {
         self.renderer.add_texture(image)
     }
 
+    fn remove_object(&mut self, object: &Self::ObjectHandle) {
+        self.renderer.remove_object(object)
+    }
+
+    fn remove_mesh(&mut self, mesh: &Self::MeshHandle) {
+        self.renderer.remove_mesh(mesh)
+    }
+
+    fn remove_texture(&mut self, texture: &Self::TextureHandle) {
+        self.renderer.remove_texture(texture)
+    }
+
     fn set_camera_location(&mut self, location: Vector3<f32>) {
         self.renderer.set_camera_location(location);
     }

--- a/bve-client/src/main.rs
+++ b/bve-client/src/main.rs
@@ -134,7 +134,7 @@ impl runtime::Client for Client {
     }
 
     fn set_object_location(&mut self, object: &Self::ObjectHandle, location: Vector3<f32>) {
-        self.renderer.set_location(&object, location);
+        self.renderer.set_location(object, location);
     }
 }
 

--- a/bve-render/src/lib.rs
+++ b/bve-render/src/lib.rs
@@ -121,7 +121,7 @@ mod texture;
 pub const OPENGL_TO_WGPU_MATRIX: Matrix4<f32> = Matrix4::new(
     1.0, 0.0, 0.0, 0.0, //
     0.0, 1.0, 0.0, 0.0, //
-    0.0, 0.0, 0.5, 0.0, //
+    0.0, 0.0, -0.5, 0.5, //
     0.0, 0.0, 0.5, 1.0,
 );
 
@@ -392,7 +392,7 @@ impl Renderer {
                     depth_store_op: StoreOp::Store,
                     stencil_load_op: LoadOp::Clear,
                     stencil_store_op: StoreOp::Store,
-                    clear_depth: 1.0,
+                    clear_depth: 0.0,
                     clear_stencil: 0,
                 }),
             });

--- a/bve-render/src/mesh.rs
+++ b/bve-render/src/mesh.rs
@@ -101,4 +101,9 @@ impl Renderer {
 
         MeshHandle(handle)
     }
+
+    pub fn remove_mesh(&mut self, MeshHandle(mesh_idx): &MeshHandle) {
+        let _mesh = self.mesh.remove(mesh_idx).expect("Invalid mesh handle");
+        // Mesh goes out of scope
+    }
 }

--- a/bve-render/src/object.rs
+++ b/bve-render/src/object.rs
@@ -18,7 +18,7 @@ pub struct Object {
 }
 
 pub fn generate_matrix(mx_view: &Matrix4<f32>, location: Vector3<f32>, aspect_ratio: f32) -> Matrix4<f32> {
-    let mx_projection = cgmath::perspective(cgmath::Deg(55_f32), aspect_ratio, 0.1, 1000.0);
+    let mx_projection = cgmath::perspective(cgmath::Deg(45_f32), aspect_ratio, 0.1, 1000.0);
     let mx_model = Matrix4::from_translation(location);
     OPENGL_TO_WGPU_MATRIX * mx_projection * mx_view * mx_model
 }
@@ -38,7 +38,11 @@ impl Renderer {
         let tex: &texture::Texture = &self.textures[tex_idx];
         let transparent = mesh.transparent || tex.transparent;
 
-        let matrix = generate_matrix(&self.camera.compute_matrix(), location, 800.0 / 600.0);
+        let matrix = generate_matrix(
+            &self.camera.compute_matrix(),
+            location,
+            self.screen_size.width as f32 / self.screen_size.height as f32,
+        );
         let matrix_ref: &[f32; 16] = matrix.as_ref();
         let uniforms = render::Uniforms {
             _matrix: *matrix_ref,

--- a/bve-render/src/object.rs
+++ b/bve-render/src/object.rs
@@ -87,4 +87,9 @@ impl Renderer {
         });
         ObjectHandle(handle)
     }
+
+    pub fn remove_object(&mut self, ObjectHandle(obj_idx): &ObjectHandle) {
+        let _object = self.objects.remove(obj_idx).expect("Invalid object handle");
+        // Object goes out of scope
+    }
 }

--- a/bve-render/src/render.rs
+++ b/bve-render/src/render.rs
@@ -151,7 +151,7 @@ pub fn create_pipeline(
         depth_stencil_state: Some(DepthStencilStateDescriptor {
             format: TextureFormat::Depth32Float,
             depth_write_enabled: true,
-            depth_compare: CompareFunction::LessEqual,
+            depth_compare: CompareFunction::GreaterEqual,
             stencil_front: StencilStateFaceDescriptor::IGNORE,
             stencil_back: StencilStateFaceDescriptor::IGNORE,
             stencil_read_mask: 0,

--- a/bve-render/src/texture.rs
+++ b/bve-render/src/texture.rs
@@ -94,8 +94,8 @@ impl Renderer {
         TextureHandle(handle)
     }
 
-    #[must_use]
-    pub const fn get_default_texture() -> TextureHandle {
-        TextureHandle(0)
+    pub fn remove_texture(&mut self, TextureHandle(tex_idx): &TextureHandle) {
+        let _texture = self.textures.remove(tex_idx).expect("Invalid texture handle");
+        // Texture goes out of scope
     }
 }

--- a/bve/Cargo.toml
+++ b/bve/Cargo.toml
@@ -22,6 +22,7 @@ chardetng = "0.1.3"
 chrono = "0.4.11"
 csv = { version = "1.1" }
 dashmap = "3.11.0"
+derive_more = { version = "0.99.5", default-features = false, features = ["as_ref", "as_mut", "deref", "display", "from", "into"] }
 encoding_rs = "0.8.22"
 fern = "0.6.0"
 fluent = "0.11.0"

--- a/bve/src/lib.rs
+++ b/bve/src/lib.rs
@@ -1,5 +1,5 @@
 //! Implementation of the high performance runtime logic for the game BVE-Reborn.
-
+#![feature(async_closure)]
 // Rust warnings
 #![warn(unused)]
 #![deny(future_incompatible)]

--- a/bve/src/runtime/cache/mesh.rs
+++ b/bve/src/runtime/cache/mesh.rs
@@ -84,7 +84,7 @@ impl<C: Client> MeshCache<C> {
         Some(mesh)
     }
 
-    pub async fn remove_mesh(&self, client: &Mutex<C>, path_handle: &PathHandle) -> Option<Vec<PathHandle>> {
+    pub async fn remove_mesh(&self, client: &Mutex<C>, path_handle: PathHandle) -> Option<Vec<PathHandle>> {
         trace!("Checking mesh {}", path_handle.0);
         self.inner
             .remove(path_handle, async move |data| {

--- a/bve/src/runtime/cache/mesh.rs
+++ b/bve/src/runtime/cache/mesh.rs
@@ -65,6 +65,8 @@ impl<C: Client> MeshCache<C> {
             mesh_data.textures.push(path_set.insert(path).await);
         }
 
+        trace!("Loaded  mesh {}", path.display());
+
         mesh_data
     }
 
@@ -72,6 +74,7 @@ impl<C: Client> MeshCache<C> {
         let canonicalized = path.canonicalize().await.ok()?;
         let path_handle = path_set.insert(canonicalized.clone()).await;
 
+        trace!("Checking if mesh {} is loaded", path_handle.0);
         let mesh = self
             .inner
             .get_or_insert(path_handle, async {
@@ -79,5 +82,19 @@ impl<C: Client> MeshCache<C> {
             })
             .await;
         Some(mesh)
+    }
+
+    pub async fn remove_mesh(&self, client: &Mutex<C>, path_handle: &PathHandle) -> Option<Vec<PathHandle>> {
+        trace!("Checking mesh {}", path_handle.0);
+        self.inner
+            .remove(path_handle, async move |data| {
+                trace!("Removing mesh {}", path_handle.0);
+                let mut client_lock = client.lock().await;
+                for (handle, _) in data.handles {
+                    client_lock.remove_mesh(&handle);
+                }
+                data.textures
+            })
+            .await
     }
 }

--- a/bve/src/runtime/cache/mod.rs
+++ b/bve/src/runtime/cache/mod.rs
@@ -68,12 +68,12 @@ impl<D: Clone> Cache<D> {
         }
     }
 
-    pub async fn remove<F, O>(&self, path_handle: &PathHandle, remove_data: impl FnOnce(D) -> F) -> Option<O>
+    pub async fn remove<F, O>(&self, path_handle: PathHandle, remove_data: impl FnOnce(D) -> F) -> Option<O>
     where
         F: Future<Output = O>,
     {
         let mut mutable_lock = self.0.lock().await;
-        if let Some(data_arc_ref) = mutable_lock.get(path_handle) {
+        if let Some(data_arc_ref) = mutable_lock.get(&path_handle) {
             let data_arc = Arc::clone(data_arc_ref);
             let data = data_arc.read().await;
             let cache_entry = data.as_ref().expect("Loaded mesh in cache without contents");
@@ -81,7 +81,7 @@ impl<D: Clone> Cache<D> {
             drop(data);
             if current_ref_count == 0 {
                 // Still have the index lock here, I am guaranteed to be the only one here
-                let contents = mutable_lock.remove(path_handle).expect("No item that we just found");
+                let contents = mutable_lock.remove(&path_handle).expect("No item that we just found");
                 let mut content_guard = contents.write().await;
                 Some(
                     remove_data(

--- a/bve/src/runtime/cache/path.rs
+++ b/bve/src/runtime/cache/path.rs
@@ -2,7 +2,7 @@ use async_std::{path::PathBuf, sync::RwLock};
 use indexmap::IndexSet;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct PathHandle(usize);
+pub struct PathHandle(pub(crate) usize);
 
 pub struct PathSet {
     inner: RwLock<IndexSet<PathBuf>>,

--- a/bve/src/runtime/cache/texture.rs
+++ b/bve/src/runtime/cache/texture.rs
@@ -71,7 +71,7 @@ impl<C: Client> TextureCache<C> {
         self.load_texture_handle_path(client, handle, resolved_path).await
     }
 
-    pub async fn remove_texture(&self, client: &Mutex<C>, path_handle: &PathHandle) -> Option<()> {
+    pub async fn remove_texture(&self, client: &Mutex<C>, path_handle: PathHandle) -> Option<()> {
         self.inner
             .remove(path_handle, async move |handle| {
                 let mut client_lock = client.lock().await;

--- a/bve/src/runtime/cache/texture.rs
+++ b/bve/src/runtime/cache/texture.rs
@@ -70,4 +70,13 @@ impl<C: Client> TextureCache<C> {
         let handle = path_set.insert(resolved_path.clone()).await;
         self.load_texture_handle_path(client, handle, resolved_path).await
     }
+
+    pub async fn remove_texture(&self, client: &Mutex<C>, path_handle: &PathHandle) -> Option<()> {
+        self.inner
+            .remove(path_handle, async move |handle| {
+                let mut client_lock = client.lock().await;
+                client_lock.remove_texture(&handle);
+            })
+            .await
+    }
 }

--- a/bve/src/runtime/chunk.rs
+++ b/bve/src/runtime/chunk.rs
@@ -15,7 +15,8 @@ pub const CHUNK_SIZE: f32 = 64.0;
 pub struct ChunkAddress(Vector2<i32>);
 
 impl ChunkAddress {
-    pub fn new(x: i32, y: i32) -> Self {
+    #[must_use]
+    pub const fn new(x: i32, y: i32) -> Self {
         Self(Vector2::new(x, y))
     }
 }
@@ -25,7 +26,8 @@ impl ChunkAddress {
 pub struct ChunkOffset(Vector3<f32>);
 
 impl ChunkOffset {
-    pub fn new(x: f32, y: f32, z: f32) -> Self {
+    #[must_use]
+    pub const fn new(x: f32, y: f32, z: f32) -> Self {
         Self(Vector3::new(x, y, z))
     }
 }

--- a/bve/src/runtime/chunk.rs
+++ b/bve/src/runtime/chunk.rs
@@ -2,6 +2,7 @@ use crate::runtime::cache::PathHandle;
 use async_std::sync::Arc;
 use cgmath::{Vector2, Vector3};
 use dashmap::{DashMap, DashSet};
+use derive_more::{AsMut, AsRef, Deref, Display, From, Into};
 use std::{
     hash::{Hash, Hasher},
     sync::atomic::AtomicU8,
@@ -9,8 +10,25 @@ use std::{
 
 pub const CHUNK_SIZE: f32 = 64.0;
 
-pub type ChunkAddress = Vector2<i32>;
-pub type ChunkOffset = Vector3<f32>;
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Deref, From, Into, Display, AsRef, AsMut)]
+#[display(fmt = "({}, {})", "self.0.x", "self.0.y")]
+pub struct ChunkAddress(Vector2<i32>);
+
+impl ChunkAddress {
+    pub fn new(x: i32, y: i32) -> Self {
+        Self(Vector2::new(x, y))
+    }
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Deref, From, Into, Display, AsRef, AsMut)]
+#[display(fmt = "({}, {}, {})", "self.0.x", "self.0.y", "self.0.z")]
+pub struct ChunkOffset(Vector3<f32>);
+
+impl ChunkOffset {
+    pub fn new(x: f32, y: f32, z: f32) -> Self {
+        Self(Vector3::new(x, y, z))
+    }
+}
 
 pub struct Chunk {
     pub address: ChunkAddress,

--- a/bve/src/runtime/chunk.rs
+++ b/bve/src/runtime/chunk.rs
@@ -7,7 +7,7 @@ use std::{
     sync::atomic::AtomicU8,
 };
 
-pub const CHUNK_SIZE: f32 = 128.0;
+pub const CHUNK_SIZE: f32 = 64.0;
 
 pub type ChunkAddress = Vector2<i32>;
 pub type ChunkOffset = Vector3<f32>;

--- a/bve/src/runtime/chunk.rs
+++ b/bve/src/runtime/chunk.rs
@@ -13,6 +13,7 @@ pub type ChunkAddress = Vector2<i32>;
 pub type ChunkOffset = Vector3<f32>;
 
 pub struct Chunk {
+    pub address: ChunkAddress,
     pub objects: DashSet<UnloadedObject>,
     pub state: AtomicU8,
 }
@@ -68,6 +69,7 @@ impl ChunkSet {
             Some(e) => Arc::clone(e.value()),
             None => {
                 let arc = Arc::new(Chunk {
+                    address,
                     objects: DashSet::new(),
                     state: AtomicU8::new(ChunkState::Unloaded as u8),
                 });

--- a/bve/src/runtime/chunk.rs
+++ b/bve/src/runtime/chunk.rs
@@ -24,6 +24,7 @@ pub enum ChunkState {
     Unloaded = 0,
     Loading = 1,
     Finished = 2,
+    Unloading = 3,
 }
 
 impl From<u8> for ChunkState {
@@ -32,6 +33,7 @@ impl From<u8> for ChunkState {
             0 => Self::Unloaded,
             1 => Self::Loading,
             2 => Self::Finished,
+            3 => Self::Unloading,
             _ => unreachable!(),
         }
     }

--- a/bve/src/runtime/client.rs
+++ b/bve/src/runtime/client.rs
@@ -17,4 +17,7 @@ pub trait Client: Send + Sync + 'static {
     ) -> Self::ObjectHandle;
     fn add_mesh(&mut self, mesh_verts: Vec<Vertex>, indices: &[usize]) -> Self::MeshHandle;
     fn add_texture(&mut self, image: &RgbaImage) -> Self::TextureHandle;
+
+    fn set_camera_location(&mut self, location: Vector3<f32>);
+    fn set_object_location(&mut self, object: &Self::ObjectHandle, location: Vector3<f32>);
 }

--- a/bve/src/runtime/client.rs
+++ b/bve/src/runtime/client.rs
@@ -18,6 +18,10 @@ pub trait Client: Send + Sync + 'static {
     fn add_mesh(&mut self, mesh_verts: Vec<Vertex>, indices: &[usize]) -> Self::MeshHandle;
     fn add_texture(&mut self, image: &RgbaImage) -> Self::TextureHandle;
 
+    fn remove_object(&mut self, object: &Self::ObjectHandle);
+    fn remove_mesh(&mut self, mesh: &Self::MeshHandle);
+    fn remove_texture(&mut self, texture: &Self::TextureHandle);
+
     fn set_camera_location(&mut self, location: Vector3<f32>);
     fn set_object_location(&mut self, object: &Self::ObjectHandle, location: Vector3<f32>);
 }

--- a/bve/src/runtime/location.rs
+++ b/bve/src/runtime/location.rs
@@ -1,8 +1,39 @@
-use crate::runtime::chunk::{ChunkAddress, ChunkOffset};
+use crate::runtime::chunk::{ChunkAddress, ChunkOffset, CHUNK_SIZE};
+use cgmath::{ElementWise, Vector3};
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Location {
     pub chunk: ChunkAddress,
     pub offset: ChunkOffset,
+}
+
+impl Location {
+    pub fn from_absolute_position(position: Vector3<f32>) -> Self {
+        let x_chunk = (position.x / CHUNK_SIZE).floor();
+        let y_chunk = (position.z / CHUNK_SIZE).floor();
+        let chunk_start_position_x = x_chunk * CHUNK_SIZE;
+        let chunk_start_position_z = y_chunk * CHUNK_SIZE;
+        Self {
+            chunk: ChunkAddress::new(x_chunk as i32, y_chunk as i32),
+            offset: ChunkOffset::new(
+                position.x - chunk_start_position_x,
+                position.y,
+                position.z - chunk_start_position_z,
+            ),
+        }
+    }
+
+    pub fn from_address_position(chunk: ChunkAddress, offset: ChunkOffset) -> Self {
+        Self { chunk, offset }
+    }
+
+    pub fn to_relative_position(&self, base_chunk: ChunkAddress) -> Vector3<f32> {
+        let chunk_offset = self.chunk.sub_element_wise(base_chunk);
+        Vector3::new(
+            chunk_offset.x as f32 * CHUNK_SIZE,
+            0.0,
+            chunk_offset.y as f32 * CHUNK_SIZE,
+        ) + self.offset
+    }
 }

--- a/bve/src/runtime/location.rs
+++ b/bve/src/runtime/location.rs
@@ -13,6 +13,7 @@ pub struct Location {
 }
 
 impl Location {
+    #[must_use]
     pub fn from_absolute_position(position: Vector3<f32>) -> Self {
         let x_chunk = (position.x / CHUNK_SIZE).floor();
         let y_chunk = (position.z / CHUNK_SIZE).floor();
@@ -28,10 +29,12 @@ impl Location {
         }
     }
 
-    pub fn from_address_position(chunk: ChunkAddress, offset: ChunkOffset) -> Self {
+    #[must_use]
+    pub const fn from_address_position(chunk: ChunkAddress, offset: ChunkOffset) -> Self {
         Self { chunk, offset }
     }
 
+    #[must_use]
     pub fn to_relative_position(&self, base_chunk: ChunkAddress) -> Vector3<f32> {
         let chunk_offset = self.chunk.as_ref().sub_element_wise(*base_chunk);
         Vector3::new(

--- a/bve/src/runtime/location.rs
+++ b/bve/src/runtime/location.rs
@@ -1,5 +1,9 @@
 use crate::runtime::chunk::{ChunkAddress, ChunkOffset, CHUNK_SIZE};
 use cgmath::{ElementWise, Vector3};
+use std::{
+    fmt,
+    fmt::{Display, Formatter},
+};
 
 #[repr(C)]
 #[derive(Debug, Copy, Clone, PartialEq)]
@@ -29,11 +33,21 @@ impl Location {
     }
 
     pub fn to_relative_position(&self, base_chunk: ChunkAddress) -> Vector3<f32> {
-        let chunk_offset = self.chunk.sub_element_wise(base_chunk);
+        let chunk_offset = self.chunk.as_ref().sub_element_wise(*base_chunk);
         Vector3::new(
             chunk_offset.x as f32 * CHUNK_SIZE,
             0.0,
             chunk_offset.y as f32 * CHUNK_SIZE,
-        ) + self.offset
+        ) + *self.offset
+    }
+}
+
+impl Display for Location {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "({}, {}):({}, {}, {})",
+            self.chunk.x, self.chunk.y, self.offset.x, self.offset.y, self.offset.z
+        )
     }
 }

--- a/bve/src/runtime/mod.rs
+++ b/bve/src/runtime/mod.rs
@@ -109,7 +109,7 @@ impl<C: Client> Runtime<C> {
 
     // TODO: This probably should get refactored inside chunk
     pub async fn add_static_object(self: &Arc<Self>, location: Location, path: PathBuf) {
-        trace!("Adding object {} to chunk {}}", path.display(), location);
+        trace!("Adding object {} to chunk {}", path.display(), location);
         let chunk = self.chunks.get_chunk(location.chunk).await;
 
         chunk.objects.insert(UnloadedObject {

--- a/bve/src/runtime/mod.rs
+++ b/bve/src/runtime/mod.rs
@@ -200,12 +200,12 @@ impl<C: Client> Runtime<C> {
     }
 
     async fn deload_mesh(self: Arc<Self>, path_handle: PathHandle) {
-        let textures_opt = self.meshes.remove_mesh(&self.client, &path_handle).await;
+        let textures_opt = self.meshes.remove_mesh(&self.client, path_handle).await;
         if let Some(textures) = textures_opt {
             for texture_handle in textures {
                 // This could be a separate task, but I don't think this will really help things, there's
                 // no major operations going on here, just locks being grabbed
-                self.textures.remove_texture(&self.client, &texture_handle).await;
+                self.textures.remove_texture(&self.client, texture_handle).await;
             }
         }
     }
@@ -270,6 +270,7 @@ impl<C: Client> Runtime<C> {
         // Handle runtime location, and spawn off job to update positions if needed
         let mut runtime_location = self.location.lock().await;
         let location = runtime_location.location;
+        #[allow(clippy::if_not_else)]
         let location_update_job = if runtime_location.location.chunk != runtime_location.old_location.chunk {
             runtime_location.old_location = runtime_location.location;
             drop(runtime_location);


### PR DESCRIPTION
A couple of renderer and runtime improvements.

- Use inverted Z for z buffer.
- Turns on the chunk/camera system. The camera never leaves the center chunk, and all the chunks move around it to create smooth movement.
- Deloading works!