### PR TITLE
Add Skybox for OpenBVE

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,7 @@ dependencies = [
  "locale_config",
  "log",
  "maplit",
+ "nalgebra-glm",
  "nom",
  "num-traits",
  "obj",
@@ -254,6 +255,7 @@ dependencies = [
  "image",
  "itertools",
  "log",
+ "nalgebra-glm",
  "num-traits",
  "serde",
  "serde_json",
@@ -326,12 +328,12 @@ version = "0.0.1"
 dependencies = [
  "async-std",
  "bve",
- "cgmath",
  "dashmap",
  "image",
  "include_dir",
  "indexmap",
  "itertools",
+ "nalgebra-glm",
  "num-traits",
  "once_cell",
  "renderdoc",
@@ -1007,6 +1009,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ed1e761351b56f54eb9dcd0cfaca9fd0daecf93918e1cfc01c8a3d26ee7adcd"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1435,6 +1446,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7d73b3f436185384286bd8098d17ec07c9a7d2388a6599f824d8502b529702a"
+
+[[package]]
 name = "line_drawing"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1494,6 +1511,15 @@ name = "maplit"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4f7ec66360130972f34830bfad9ef05c6610a43938a467bcc9ab9369ab3478f"
+dependencies = [
+ "rawpointer",
+]
 
 [[package]]
 name = "maybe-uninit"
@@ -1596,6 +1622,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "nalgebra"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d630f146ae751cfb43db9e0ad6bd73819a546a38baa5d4a9de69823c389c78a1"
+dependencies = [
+ "approx",
+ "generic-array",
+ "matrixmultiply",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "rand",
+ "rand_distr",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-glm"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0689d473f0cbf5d763219dc9faf5d3c3136d20583f533317cc9463f85400ca1"
+dependencies = [
+ "approx",
+ "nalgebra",
+ "num-traits",
+ "simba",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1627,6 +1683,16 @@ checksum = "0b471253da97532da4b61552249c521e01e736071f71c1a4f7ebbfbf0a06aad6"
 dependencies = [
  "memchr",
  "version_check",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+dependencies = [
+ "autocfg",
+ "num-traits",
 ]
 
 [[package]]
@@ -1668,6 +1734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c62be47e61d1842b9170f0fdeec8eba98e60e90e5446449a0545e5152acd7096"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1770,6 +1837,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3c897744f63f34f7ae3a024d9162bb5001f4ad661dd24bea0dc9f075d2de1c6"
+dependencies = [
+ "paste-impl",
+ "proc-macro-hack",
+]
+
+[[package]]
+name = "paste-impl"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fd6f92e3594f2dd7b3fc23e42d82e292f7bcda6d8e5dcd167072327234ab89"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2 1.0.10",
+ "quote 1.0.3",
+ "syn",
+]
+
+[[package]]
 name = "peek-poke"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1834,6 +1923,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74490b50b9fbe561ac330df47c08f3f33073d2d00c150f719147d7c54522fa1b"
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1888,6 +1983,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
+dependencies = [
+ "getrandom",
+ "libc",
+ "rand_chacha",
+ "rand_core",
+ "rand_hc",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
+name = "rand_distr"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96977acbdd3a6576fb1d27391900035bf3863d4a16422973a409b488cf29ffb2"
+dependencies = [
+ "rand",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "range-alloc"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1901,6 +2046,12 @@ checksum = "0a441a7a6c80ad6473bd4b74ec1c9a4c951794285bf941c2126f607c72e48211"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "redox_syscall"
@@ -2074,6 +2225,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simba"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d771bffb178827708f83829713e3a214bc8a9879a8f27ca548965bd849ed130"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2223,6 +2386,12 @@ checksum = "9d2741b1474c327d95c1f1e3b0a2c3977c8e128409c572a33af2914e7d636717"
 dependencies = [
  "fxhash",
 ]
+
+[[package]]
+name = "typenum"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "unic-langid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1256,6 +1256,7 @@ dependencies = [
  "bytemuck",
  "byteorder",
  "gif",
+ "jpeg-decoder",
  "num-iter",
  "num-rational",
  "num-traits",
@@ -1388,6 +1389,15 @@ name = "itoa"
 version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b47b4c4e017b01abdc5bcc126d2d1002e5a75bbe3ce73f9f4f311a916363704"
+dependencies = [
+ "byteorder",
+]
 
 [[package]]
 name = "js-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ opt-level = 0
 [profile.dev.package.pico-args]
 opt-level = 0
 
+[profile.opt-dev]
+inherits = "dev"
+opt-level = 1
+
 [profile.dev.package."*"]
 opt-level = 3
 

--- a/bve-build/src/main.rs
+++ b/bve-build/src/main.rs
@@ -51,7 +51,7 @@
 use crate::shaders::{ShaderCombination, ShaderType, SingleDefine};
 use itertools::Itertools;
 use std::{
-    fs::{create_dir_all, metadata, read_to_string, remove_dir_all, File},
+    fs::{create_dir_all, metadata, read_to_string, remove_dir_all},
     path::Path,
     process::{exit, Command},
 };
@@ -201,14 +201,13 @@ fn mangle_shader_name(combination: &ShaderCombination<'_>) -> String {
 }
 
 fn build_shaders() {
-    if Path::new("bve-render/shaders/spirv/.timestamp").exists()
-        && out_of_date("bve-render/shaders/compile", "bve-render/shaders/spirv/.timestamp")
+    if Path::new("bve-render/shaders/spirv").exists()
+        && out_of_date("bve-render/shaders/compile", "bve-render/shaders/spirv/")
     {
         remove_dir_all("bve-render/shaders/spirv").expect("Could not remove directory");
         println!("Removing out of date spirv directory")
     }
     create_dir_all("bve-render/shaders/spirv").expect("Could not create spirv directory");
-    File::create("bve-render/shaders/spirv/.timestamp").expect("Could not create timestamp");
     for combination in
         shaders::parse_shader_compile_file(&read_to_string("bve-render/shaders/compile").unwrap()).unwrap()
     {

--- a/bve-client/Cargo.toml
+++ b/bve-client/Cargo.toml
@@ -25,6 +25,7 @@ bve-render = { version = "0.0.1", path = "../bve-render" }
 cgmath = "0.17.0"
 env_logger = "0.7.1"
 image = { version = "0.23.2", default-features = false, features = ["bmp", "gif", "png"] }
+nalgebra-glm = "0.7.0"
 num-traits = "0.2.11"
 itertools = "0.9"
 log = "0.4.8"

--- a/bve-client/Cargo.toml
+++ b/bve-client/Cargo.toml
@@ -24,7 +24,7 @@ bve = { version = "0.0.1", path = "../bve" }
 bve-render = { version = "0.0.1", path = "../bve-render" }
 cgmath = "0.17.0"
 env_logger = "0.7.1"
-image = { version = "0.23.2", default-features = false, features = ["bmp", "gif", "png"] }
+image = { version = "0.23.2", default-features = false, features = ["bmp", "gif", "png", "jpeg"] }
 nalgebra-glm = "0.7.0"
 num-traits = "0.2.11"
 itertools = "0.9"

--- a/bve-client/src/main.rs
+++ b/bve-client/src/main.rs
@@ -149,7 +149,14 @@ struct Object {
 }
 
 #[derive(Deserialize)]
+struct Background {
+    path: std::path::PathBuf,
+    repeats: f32,
+}
+
+#[derive(Deserialize)]
 struct Loading {
+    background: Background,
     objects: Vec<Object>,
 }
 
@@ -203,6 +210,16 @@ fn client_main() {
                     .await
             }
         }
+
+        let image_contents = async_std::fs::read(&loading.background.path)
+            .await
+            .expect("Could not load background image");
+        let rgba = image::load_from_memory(&image_contents)
+            .expect("Could not load background image")
+            .into_rgba();
+        let mut client = client.lock().await;
+        let handle = client.renderer.add_texture(&rgba);
+        client.renderer.set_skybox_image(&handle, loading.background.repeats);
     });
 
     let mut mouse_pitch = 0.0_f32;

--- a/bve-client/src/main.rs
+++ b/bve-client/src/main.rs
@@ -62,6 +62,7 @@ use bve_render::{MSAASetting, MeshHandle, OITNodeCount, ObjectHandle, Renderer, 
 use cgmath::{ElementWise, InnerSpace, Vector3};
 use image::RgbaImage;
 use itertools::Itertools;
+use nalgebra_glm::Vec3;
 use num_traits::Zero;
 use serde::Deserialize;
 use std::{
@@ -95,13 +96,13 @@ impl runtime::Client for Client {
     type MeshHandle = MeshHandle;
     type TextureHandle = TextureHandle;
 
-    fn add_object(&mut self, location: Vector3<f32>, mesh: &Self::MeshHandle) -> Self::ObjectHandle {
+    fn add_object(&mut self, location: Vec3, mesh: &Self::MeshHandle) -> Self::ObjectHandle {
         self.renderer.add_object(location, mesh)
     }
 
     fn add_object_texture(
         &mut self,
-        location: Vector3<f32>,
+        location: Vec3,
         mesh: &Self::MeshHandle,
         texture: &Self::TextureHandle,
     ) -> Self::ObjectHandle {
@@ -128,11 +129,11 @@ impl runtime::Client for Client {
         self.renderer.remove_texture(texture)
     }
 
-    fn set_camera_location(&mut self, location: Vector3<f32>) {
+    fn set_camera_location(&mut self, location: Vec3) {
         self.renderer.set_camera_location(location);
     }
 
-    fn set_object_location(&mut self, object: &Self::ObjectHandle, location: Vector3<f32>) {
+    fn set_object_location(&mut self, object: &Self::ObjectHandle, location: Vec3) {
         self.renderer.set_location(object, location);
     }
 }
@@ -348,8 +349,8 @@ fn client_main() {
             if !grabber.get_grabbed() {
                 return;
             }
-            mouse_yaw += (-delta_x / 1000.0) as f32;
-            mouse_pitch += (-delta_y / 1000.0) as f32;
+            mouse_yaw += (delta_x / 1000.0) as f32;
+            mouse_pitch += (delta_y / 1000.0) as f32;
             if mouse_yaw < 0.0 {
                 mouse_yaw += TAU;
             } else if mouse_yaw >= TAU {

--- a/bve-render/Cargo.toml
+++ b/bve-render/Cargo.toml
@@ -19,8 +19,8 @@ default = []
 [dependencies]
 async-std = "1.5.0"
 bve = { version = "0.0.1", path = "../bve" }
-cgmath = "0.17.0"
 dashmap = "3.11.1"
+nalgebra-glm = "0.7.0"
 num-traits = "0.2.11"
 include_dir = "0.5.0"
 indexmap = "1.3.2"

--- a/bve-render/shaders/compile
+++ b/bve-render/shaders/compile
@@ -4,4 +4,6 @@ oit_pass1 - fragment:
 oit_pass2 - fragment: MAX_SAMPLES=1 OR MAX_SAMPLES=2 OR MAX_SAMPLES=4 OR MAX_SAMPLES=8 AND MAX_NODES=4 OR MAX_NODES=8 OR MAX_NODES=16 OR MAX_NODES=32
 opaque - vertex:
 opaque - fragment:
+skybox - vertex:
+skybox - fragment:
 transparency - compute:

--- a/bve-render/shaders/skybox.fs.glsl
+++ b/bve-render/shaders/skybox.fs.glsl
@@ -1,14 +1,19 @@
 #version 450
 
-layout(location = 0) in vec3 view_position;
+layout(location = 0) in vec2 clip_position;
 layout(location = 0) out vec4 outColor;
 
-layout(set = 1, binding = 1) uniform texture2D skybox;
-layout(set = 1, binding = 2) uniform sampler skybox_sampler;
+layout(set = 0, binding = 0) uniform Matrices {
+    mat4 inv_view_proj;
+};
+layout(set = 1, binding = 0) uniform texture2D skybox;
+layout(set = 1, binding = 1) uniform sampler skybox_sampler;
 
 void main() {
-    float yaw = acos(dot(vec3(0.0, 0.0, 1.0), normalize(vec3(view_position.x, 0.0, view_position.z))));
-    float pitch = acos(dot(vec3(1.0, 0.0, 0.0), normalize(vec3(0.0, view_position.y, view_position.z))));
+    vec4 clip = vec4(clip_position, 1.0, 1.0);
+    vec4 world = inv_view_proj * clip;
+    world.xyz /= world.w;
+    world.xy *= -1.0;
 
-    outColor = vec4(normalize(view_position), 1.0);
+    outColor = vec4(pow(vec3(normalize(world)), vec3(1 / 2.2)), 1.0);
 }

--- a/bve-render/shaders/skybox.fs.glsl
+++ b/bve-render/shaders/skybox.fs.glsl
@@ -1,15 +1,22 @@
 #version 450
 
-#define PI 3.1415926535626433
+#define PI_3 1.0471975511965977
+#define PI_2 1.5707963267948966
+#define PI   3.1415926535626433
+#define TAU  6.2831853071795865
 
 layout(location = 0) in vec2 clip_position;
-layout(location = 0) out vec4 outColor;
+layout(location = 0) out vec3 outColor;
 
 layout(set = 0, binding = 0) uniform Matrices {
     mat4 inv_view_proj;
 };
-layout(set = 1, binding = 0) uniform texture2D skybox;
+layout(set = 1, binding = 0) uniform utexture2D skybox;
 layout(set = 1, binding = 1) uniform sampler skybox_sampler;
+
+float wrap(float value, float min, float max) {
+    return mod(value - min, max - min) + min;
+}
 
 void main() {
     vec4 clip = vec4(clip_position, 1.0, 1.0);
@@ -23,5 +30,22 @@ void main() {
     float inv_yaw = -atan(world_dir.x, -world_dir.z) + PI;
     float pitch = asin(world_dir.y) * 2 + PI;
 
-    outColor = vec4(vec2(yaw / (PI * 2), 0.0), 0.0, 1.0);
+    // Add PI/3 so that the split point is 60 deg to the left of +z
+    float x_coord = wrap(inv_yaw + PI_3, 0, TAU) / TAU;
+    float y_coord;
+    if (pitch <= PI) {
+        // Below the horizon only gets 25% of the image
+        y_coord = (pitch / 2) / TAU;
+    }
+    else {
+        // Above the horizon gets 75% of the image
+        y_coord = (pitch / TAU) * 1.5 - 0.5;
+    }
+
+    vec4 texture_srgb = vec4(texture(usampler2D(skybox, skybox_sampler), vec2(x_coord, y_coord))) / 255;
+    vec4 texture = vec4(pow(texture_srgb.rgb, vec3(1 / 2.2)), texture_srgb.a);
+
+    vec3 blended = mix(vec3(0.0), texture.rgb, texture.a);
+
+    outColor = blended;
 }

--- a/bve-render/shaders/skybox.fs.glsl
+++ b/bve-render/shaders/skybox.fs.glsl
@@ -1,5 +1,7 @@
 #version 450
 
+#define PI 3.1415926535626433
+
 layout(location = 0) in vec2 clip_position;
 layout(location = 0) out vec4 outColor;
 
@@ -13,6 +15,13 @@ void main() {
     vec4 clip = vec4(clip_position, 1.0, 1.0);
     vec4 world = inv_view_proj * clip;
     world.xyz /= world.w;
+    vec3 world_dir = normalize(vec3(world));
 
-    outColor = vec4(pow(vec3(normalize(world)), vec3(1 / 2.2)), 1.0);
+    // both [0, tau]
+    // normally atan is [-pi, pi] around +z, but we want it [0, tau] around +z, so we need to flip Z and offset it by PI.
+    // The normal rotation direction is counter clockwise -pi -> pi, but we need clockwise, so flip the resulting sign to make it pi -> -pi.
+    float inv_yaw = -atan(world_dir.x, -world_dir.z) + PI;
+    float pitch = asin(world_dir.y) * 2 + PI;
+
+    outColor = vec4(vec2(yaw / (PI * 2), 0.0), 0.0, 1.0);
 }

--- a/bve-render/shaders/skybox.fs.glsl
+++ b/bve-render/shaders/skybox.fs.glsl
@@ -1,0 +1,14 @@
+#version 450
+
+layout(location = 0) in vec3 view_position;
+layout(location = 0) out vec4 outColor;
+
+layout(set = 1, binding = 1) uniform texture2D skybox;
+layout(set = 1, binding = 2) uniform sampler skybox_sampler;
+
+void main() {
+    float yaw = acos(dot(vec3(0.0, 0.0, 1.0), normalize(vec3(view_position.x, 0.0, view_position.z))));
+    float pitch = acos(dot(vec3(1.0, 0.0, 0.0), normalize(vec3(0.0, view_position.y, view_position.z))));
+
+    outColor = vec4(normalize(view_position), 1.0);
+}

--- a/bve-render/shaders/skybox.fs.glsl
+++ b/bve-render/shaders/skybox.fs.glsl
@@ -13,7 +13,6 @@ void main() {
     vec4 clip = vec4(clip_position, 1.0, 1.0);
     vec4 world = inv_view_proj * clip;
     world.xyz /= world.w;
-    world.xy *= -1.0;
 
     outColor = vec4(pow(vec3(normalize(world)), vec3(1 / 2.2)), 1.0);
 }

--- a/bve-render/shaders/skybox.fs.glsl
+++ b/bve-render/shaders/skybox.fs.glsl
@@ -6,10 +6,11 @@
 #define TAU  6.2831853071795865
 
 layout(location = 0) in vec2 clip_position;
-layout(location = 0) out vec3 outColor;
+layout(location = 0) out vec4 outColor;
 
 layout(set = 0, binding = 0) uniform Matrices {
     mat4 inv_view_proj;
+    float repeats;
 };
 layout(set = 1, binding = 0) uniform utexture2D skybox;
 layout(set = 1, binding = 1) uniform sampler skybox_sampler;
@@ -31,7 +32,8 @@ void main() {
     float pitch = asin(world_dir.y) * 2 + PI;
 
     // Add PI/3 so that the split point is 60 deg to the left of +z
-    float x_coord = wrap(inv_yaw + PI_3, 0, TAU) / TAU;
+    float x_coord = wrap(inv_yaw + PI_3, 0.0, TAU) / TAU;
+    x_coord *= repeats;
     float y_coord;
     if (pitch <= PI) {
         // Below the horizon only gets 25% of the image
@@ -42,10 +44,8 @@ void main() {
         y_coord = (pitch / TAU) * 1.5 - 0.5;
     }
 
-    vec4 texture_srgb = vec4(texture(usampler2D(skybox, skybox_sampler), vec2(x_coord, y_coord))) / 255;
-    vec4 texture = vec4(pow(texture_srgb.rgb, vec3(1 / 2.2)), texture_srgb.a);
+    vec4 texture_srgb = vec4(texture(usampler2D(skybox, skybox_sampler), vec2(x_coord, 1 - y_coord))) / 255;
+    vec3 texture = pow(texture_srgb.rgb, vec3(2.2));
 
-    vec3 blended = mix(vec3(0.0), texture.rgb, texture.a);
-
-    outColor = blended;
+    outColor = vec4(texture, 1.0);
 }

--- a/bve-render/shaders/skybox.fs.glsl
+++ b/bve-render/shaders/skybox.fs.glsl
@@ -44,8 +44,8 @@ void main() {
         y_coord = (pitch / TAU) * 1.5 - 0.5;
     }
 
-    vec4 texture_srgb = vec4(texture(usampler2D(skybox, skybox_sampler), vec2(x_coord, 1 - y_coord))) / 255;
-    vec3 texture = pow(texture_srgb.rgb, vec3(2.2));
+    vec4 background_srgb = vec4(texture(usampler2D(skybox, skybox_sampler), vec2(x_coord, 1 - y_coord))) / 255;
+    vec3 background = pow(background_srgb.rgb, vec3(2.2));
 
-    outColor = vec4(texture, 1.0);
+    outColor = vec4(background, 1.0);
 }

--- a/bve-render/shaders/skybox.vs.glsl
+++ b/bve-render/shaders/skybox.vs.glsl
@@ -1,0 +1,17 @@
+#version 450
+
+layout(location = 0) in vec3 position;
+
+layout(location = 0) out vec3 o_view_position;
+
+layout(set = 0, binding = 0) uniform Matrices {
+    mat4 mvp;
+    mat4 mv;
+};
+
+void main() {
+    o_view_position = mat3(mv) * position;
+    vec4 clip = mvp * vec4(position, 1.0);
+    // Perform perspective divide myself so I can set z to 0.0
+    gl_Position = clip;
+}

--- a/bve-render/shaders/skybox.vs.glsl
+++ b/bve-render/shaders/skybox.vs.glsl
@@ -1,17 +1,10 @@
 #version 450
 
-layout(location = 0) in vec3 position;
+layout(location = 0) in vec2 position;
 
-layout(location = 0) out vec3 o_view_position;
-
-layout(set = 0, binding = 0) uniform Matrices {
-    mat4 mvp;
-    mat4 mv;
-};
+layout(location = 0) out vec2 o_clip_position;
 
 void main() {
-    o_view_position = mat3(mv) * position;
-    vec4 clip = mvp * vec4(position, 1.0);
-    // Perform perspective divide myself so I can set z to 0.0
-    gl_Position = clip;
+    o_clip_position = position;
+    gl_Position = vec4(o_clip_position, 1.0, 1.0);
 }

--- a/bve-render/src/camera.rs
+++ b/bve-render/src/camera.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use cgmath::{Array, EuclideanSpace, Matrix3, Matrix4, Point3, Rad, SquareMatrix, Vector3, Vector4};
+use cgmath::{EuclideanSpace, Matrix3, Matrix4, Point3, Rad, SquareMatrix, Vector3, Vector4};
 
 pub struct Camera {
     pub location: Vector3<f32>,
@@ -33,12 +33,9 @@ impl Camera {
         // This is pre z-inversion, so z is flipped here
         let look_offset = self.compute_look_offset();
 
-        Matrix4::from_diagonal(Vector4::new(1.0, 1.0, -1.0, 1.0))
-            * Matrix4::look_at(
-                Point3::from_value(0.0),
-                Point3::from_vec(look_offset),
-                Vector3::unit_y(),
-            )
+        Matrix4::from(
+            Matrix3::from_diagonal(Vector3::new(-1.0, 1.0, -1.0)) * Matrix3::look_at(look_offset, -Vector3::unit_y()),
+        )
     }
 }
 

--- a/bve-render/src/camera.rs
+++ b/bve-render/src/camera.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use cgmath::{EuclideanSpace, Matrix3, Matrix4, Point3, Rad, SquareMatrix, Vector3, Vector4};
+use cgmath::{Array, EuclideanSpace, Matrix3, Matrix4, Point3, Rad, SquareMatrix, Vector3, Vector4};
 
 pub struct Camera {
     pub location: Vector3<f32>,
@@ -10,17 +10,33 @@ pub struct Camera {
 }
 
 impl Camera {
-    pub fn compute_matrix(&self) -> Matrix4<f32> {
+    pub fn compute_look_offset(&self) -> Vector3<f32> {
         // This is pre z-inversion, so z is flipped here
-        let look_offset = Matrix3::from_diagonal(Vector3::new(1.0, 1.0, -1.0))
+        Matrix3::from_diagonal(Vector3::new(1.0, 1.0, -1.0))
             * Matrix3::from_axis_angle(Vector3::unit_y(), Rad(self.yaw))
             * Matrix3::from_axis_angle(Vector3::unit_x(), Rad(self.pitch))
-            * Vector3::unit_z();
+            * Vector3::unit_z()
+    }
+
+    pub fn compute_matrix(&self) -> Matrix4<f32> {
+        let look_offset = self.compute_look_offset();
 
         Matrix4::from_diagonal(Vector4::new(1.0, 1.0, -1.0, 1.0))
             * Matrix4::look_at(
                 Point3::from_vec(self.location),
                 Point3::from_vec(self.location + look_offset),
+                Vector3::unit_y(),
+            )
+    }
+
+    pub fn compute_origin_matrix(&self) -> Matrix4<f32> {
+        // This is pre z-inversion, so z is flipped here
+        let look_offset = self.compute_look_offset();
+
+        Matrix4::from_diagonal(Vector4::new(1.0, 1.0, -1.0, 1.0))
+            * Matrix4::look_at(
+                Point3::from_value(0.0),
+                Point3::from_vec(look_offset),
                 Vector3::unit_y(),
             )
     }

--- a/bve-render/src/compute.rs
+++ b/bve-render/src/compute.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use cgmath::Vector2;
+use nalgebra_glm::UVec2;
 use std::mem::size_of;
 use zerocopy::AsBytes;
 
@@ -59,7 +59,7 @@ fn create_texture_compute_pipeline(
     (pipeline, bind_group_layout)
 }
 
-fn create_uniform_buffer(device: &Device, encoder: &mut CommandEncoder, max_size: Vector2<u32>) -> Buffer {
+fn create_uniform_buffer(device: &Device, encoder: &mut CommandEncoder, max_size: UVec2) -> Buffer {
     let uniforms = Uniforms {
         _max_size: *max_size.as_ref(),
     };
@@ -120,7 +120,7 @@ impl MipmapCompute {
         }
     }
 
-    pub fn compute_mipmaps(&self, device: &Device, texture: &Texture, dimensions: Vector2<u32>) -> Vec<CommandBuffer> {
+    pub fn compute_mipmaps(&self, device: &Device, texture: &Texture, dimensions: UVec2) -> Vec<CommandBuffer> {
         let mut buffers = Vec::new();
 
         for (level, dimensions) in render::enumerate_mip_levels(dimensions) {
@@ -185,7 +185,7 @@ impl CutoutTransparencyCompute {
         device: &Device,
         texture: &Texture,
         texture_dst: &Texture,
-        dimensions: Vector2<u32>,
+        dimensions: UVec2,
     ) -> CommandBuffer {
         let view = TextureViewDescriptor {
             dimension: TextureViewDimension::D2,

--- a/bve-render/src/lib.rs
+++ b/bve-render/src/lib.rs
@@ -424,7 +424,7 @@ impl Renderer {
 
             self.skybox_renderer.render_skybox(
                 &mut rpass,
-                &self.textures[&0].bind_group,
+                &self.textures[&self.skybox_renderer.texture_id].bind_group,
                 &self.screenspace_triangle_verts,
             );
         }

--- a/bve-render/src/lib.rs
+++ b/bve-render/src/lib.rs
@@ -389,12 +389,6 @@ impl Renderer {
                 }),
             });
 
-            self.skybox_renderer.render_skybox(
-                &mut rpass,
-                &self.textures[&0].bind_group,
-                &self.screenspace_triangle_verts,
-            );
-
             // If se don't have a matrix buffer we have nothing to render
             if let Some(matrix_buffer) = matrix_buffer_opt.as_ref() {
                 let mut current_matrix_offset = 0 as BufferAddress;
@@ -427,6 +421,12 @@ impl Renderer {
                     }
                 }
             }
+
+            self.skybox_renderer.render_skybox(
+                &mut rpass,
+                &self.textures[&0].bind_group,
+                &self.screenspace_triangle_verts,
+            );
         }
         {
             let mut rpass = encoder.begin_render_pass(&RenderPassDescriptor {

--- a/bve-render/src/mesh.rs
+++ b/bve-render/src/mesh.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use nalgebra_glm::zero;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MeshHandle(pub(crate) u64);
@@ -9,7 +10,7 @@ pub struct Mesh {
     pub index_buffer: Buffer,
     pub index_count: u32,
 
-    pub mesh_center_offset: Vector3<f32>,
+    pub mesh_center_offset: Vec3,
     pub transparent: bool,
 }
 
@@ -52,20 +53,20 @@ pub fn convert_mesh_verts_to_render_verts(
     (out_verts, indices)
 }
 
-pub fn find_mesh_center(mesh: &[render::Vertex]) -> Vector3<f32> {
+pub fn find_mesh_center(mesh: &[render::Vertex]) -> Vec3 {
     let first = if let Some(first) = mesh.first() {
         *first
     } else {
-        return Vector3::zero();
+        return zero();
     };
     // Bounding box time baby!
-    let mut max: Vector3<f32> = first.pos.into();
-    let mut min: Vector3<f32> = first.pos.into();
+    let mut max: Vec3 = make_vec3(&first.pos);
+    let mut min: Vec3 = make_vec3(&first.pos);
 
     for vert in mesh.iter().skip(1) {
-        let pos: Vector3<f32> = vert.pos.into();
-        max = max.zip(pos, |left, right| left.max(right));
-        min = min.zip(pos, |left, right| left.min(right));
+        let pos: Vec3 = vert.pos.into();
+        max = max.zip_map(&pos, |left, right| left.max(right));
+        min = min.zip_map(&pos, |left, right| left.min(right));
     }
 
     (max + min) / 2.0

--- a/bve-render/src/object.rs
+++ b/bve-render/src/object.rs
@@ -33,10 +33,9 @@ pub fn perspective_matrix(fovy: impl Into<Rad<f32>>, aspect: f32, z_near: f32) -
     result
 }
 
-pub fn generate_matrix(mx_view: &Matrix4<f32>, location: Vector3<f32>, aspect_ratio: f32) -> Matrix4<f32> {
-    let mx_projection = perspective_matrix(cgmath::Deg(45_f32), aspect_ratio, 0.1);
+pub fn generate_matrix(mx_proj: &Matrix4<f32>, mx_view: &Matrix4<f32>, location: Vector3<f32>) -> Matrix4<f32> {
     let mx_model = Matrix4::from_translation(location);
-    OPENGL_TO_WGPU_MATRIX * mx_projection * mx_view * mx_model
+    OPENGL_TO_WGPU_MATRIX * mx_proj * mx_view * mx_model
 }
 
 impl Renderer {

--- a/bve-render/src/object.rs
+++ b/bve-render/src/object.rs
@@ -15,22 +15,6 @@ pub struct Object {
 }
 
 pub fn perspective_matrix(fovy: f32, aspect: f32) -> Mat4 {
-    // let range = (fovy / 2.0).tan() * z_near;
-    //
-    // let left = -range * aspect;
-    // let right = range * aspect;
-    // let bottom = -range;
-    // let top = range;
-    //
-    // let mut result: Mat4 = zero();
-    //
-    // result.m11 = (2.0 * z_near) / (right - left);
-    // result.m22 = (2.0 * z_near) / (top - bottom);
-    // result.m33 = 1.0;
-    // result.m34 = 1.0;
-    // result.m43 = -2.0 * z_near;
-
-    // result
     perspective_lh_zo(aspect, fovy, 0.1, 10000.0)
 }
 

--- a/bve-render/src/object.rs
+++ b/bve-render/src/object.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use cgmath::{Rad, SquareMatrix};
+use nalgebra_glm::{perspective_lh_zo, translation, Mat4, Vec3};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ObjectHandle(pub(crate) u64);
@@ -8,44 +8,45 @@ pub struct Object {
     pub mesh: u64,
     pub texture: u64,
 
-    pub location: Vector3<f32>,
+    pub location: Vec3,
     pub camera_distance: f32,
 
     pub transparent: bool,
 }
 
-pub fn perspective_matrix(fovy: impl Into<Rad<f32>>, aspect: f32, z_near: f32) -> Matrix4<f32> {
-    let range = (fovy.into().0 / 2.0).tan() * z_near;
+pub fn perspective_matrix(fovy: f32, aspect: f32) -> Mat4 {
+    // let range = (fovy / 2.0).tan() * z_near;
+    //
+    // let left = -range * aspect;
+    // let right = range * aspect;
+    // let bottom = -range;
+    // let top = range;
+    //
+    // let mut result: Mat4 = zero();
+    //
+    // result.m11 = (2.0 * z_near) / (right - left);
+    // result.m22 = (2.0 * z_near) / (top - bottom);
+    // result.m33 = 1.0;
+    // result.m34 = 1.0;
+    // result.m43 = -2.0 * z_near;
 
-    let left = -range * aspect;
-    let right = range * aspect;
-    let bottom = -range;
-    let top = range;
-
-    let mut result = Matrix4::from_value(0.0);
-
-    result.x.x = (2.0 * z_near) / (right - left);
-    result.y.y = (2.0 * z_near) / (top - bottom);
-    result.z.z = -1.0;
-    result.z.w = -1.0;
-    result.w.z = -2.0 * z_near;
-
-    result
+    // result
+    perspective_lh_zo(aspect, fovy, 0.1, 10000.0)
 }
 
-pub fn generate_matrix(mx_proj: &Matrix4<f32>, mx_view: &Matrix4<f32>, location: Vector3<f32>) -> Matrix4<f32> {
-    let mx_model = Matrix4::from_translation(location);
-    OPENGL_TO_WGPU_MATRIX * mx_proj * mx_view * mx_model
+pub fn generate_matrix(mx_proj: &Mat4, mx_view: &Mat4, location: Vec3) -> Mat4 {
+    let mx_model = translation(&location);
+    mx_proj * mx_view * mx_model
 }
 
 impl Renderer {
-    pub fn add_object(&mut self, location: Vector3<f32>, mesh_handle: &mesh::MeshHandle) -> ObjectHandle {
+    pub fn add_object(&mut self, location: Vec3, mesh_handle: &mesh::MeshHandle) -> ObjectHandle {
         self.add_object_texture(location, mesh_handle, &texture::TextureHandle::default())
     }
 
     pub fn add_object_texture(
         &mut self,
-        location: Vector3<f32>,
+        location: Vec3,
         mesh::MeshHandle(mesh_idx): &mesh::MeshHandle,
         texture::TextureHandle(tex_idx): &texture::TextureHandle,
     ) -> ObjectHandle {

--- a/bve-render/src/oit.rs
+++ b/bve-render/src/oit.rs
@@ -1,4 +1,7 @@
-use crate::*;
+use crate::{
+    render::{vert, ScreenSpaceVertex},
+    *,
+};
 use zerocopy::AsBytes;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -332,18 +335,8 @@ fn create_node_buffer_header() -> Vec<u8> {
     vec
 }
 
-#[derive(AsBytes)]
-#[repr(C)]
-struct ScreenSpaceVertex {
-    _vertices: [f32; 2],
-}
-
-const fn vert(arg: [f32; 2]) -> ScreenSpaceVertex {
-    ScreenSpaceVertex { _vertices: arg }
-}
-
 fn create_screen_space_verts(device: &Device) -> Buffer {
-    let data = vec![vert([-3.0, -3.0]), vert([3.0, -3.0]), vert([0.0, 3.0])];
+    let data = [vert([-3.0, -3.0]), vert([3.0, -3.0]), vert([0.0, 3.0])];
     device.create_buffer_with_data(data.as_bytes(), BufferUsage::VERTEX)
 }
 

--- a/bve-render/src/oit.rs
+++ b/bve-render/src/oit.rs
@@ -1,4 +1,5 @@
 use crate::{screenspace::ScreenSpaceVertex, *};
+use nalgebra_glm::UVec2;
 use zerocopy::AsBytes;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -64,7 +65,7 @@ fn create_pipeline_pass1(
         depth_stencil_state: Some(DepthStencilStateDescriptor {
             format: TextureFormat::Depth32Float,
             depth_write_enabled: false,
-            depth_compare: CompareFunction::GreaterEqual,
+            depth_compare: CompareFunction::LessEqual,
             stencil_front: StencilStateFaceDescriptor::IGNORE,
             stencil_back: StencilStateFaceDescriptor::IGNORE,
             stencil_read_mask: 0,
@@ -153,7 +154,7 @@ fn create_uniform_buffer(
     node_buffer: &Buffer,
     framebuffer: &TextureView,
     framebuffer_sampler: &Sampler,
-    resolution: Vector2<u32>,
+    resolution: UVec2,
     samples: MSAASetting,
 ) -> (Buffer, BindGroup, BindGroup) {
     let max_nodes = node_count(resolution);
@@ -213,7 +214,7 @@ fn create_oit_buffers(
     framebuffer_bind_group_layout: &BindGroupLayout,
     framebuffer: &TextureView,
     framebuffer_sampler: &Sampler,
-    resolution: Vector2<u32>,
+    resolution: UVec2,
     samples: MSAASetting,
 ) -> (TextureView, Buffer, Buffer, BindGroup, BindGroup) {
     let head_pointer_source_buffer = device.create_buffer_with_data(
@@ -317,11 +318,11 @@ fn create_pass2_pipeline_layout(
 
 const SIZE_OF_NODE: usize = 28;
 
-const fn node_count(resolution: Vector2<u32>) -> u32 {
+fn node_count(resolution: UVec2) -> u32 {
     resolution.x * resolution.y * 5
 }
 
-const fn size_of_node_buffer(resolution: Vector2<u32>) -> BufferAddress {
+fn size_of_node_buffer(resolution: UVec2) -> BufferAddress {
     (node_count(resolution) as usize * SIZE_OF_NODE + 4) as BufferAddress
 }
 
@@ -350,7 +351,7 @@ pub struct Oit {
 
     framebuffer_sampler: Sampler,
 
-    resolution: Vector2<u32>,
+    resolution: UVec2,
 
     pass1_pipeline: RenderPipeline,
     pass2_pipeline: RenderPipeline,
@@ -362,7 +363,7 @@ impl Oit {
         vert: &ShaderModule,
         opaque_bind_group_layout: &BindGroupLayout,
         framebuffer: &TextureView,
-        resolution: Vector2<u32>,
+        resolution: UVec2,
         oit_node_count: OITNodeCount,
         samples: MSAASetting,
     ) -> (Self, CommandBuffer) {
@@ -459,7 +460,7 @@ impl Oit {
     pub fn resize(
         &mut self,
         device: &Device,
-        resolution: Vector2<u32>,
+        resolution: UVec2,
         framebuffer: &TextureView,
         samples: MSAASetting,
     ) -> CommandBuffer {
@@ -494,7 +495,7 @@ impl Oit {
         device: &Device,
         vert: &ShaderModule,
         framebuffer: &TextureView,
-        resolution: Vector2<u32>,
+        resolution: UVec2,
         oit_node_count: OITNodeCount,
         samples: MSAASetting,
     ) {

--- a/bve-render/src/render.rs
+++ b/bve-render/src/render.rs
@@ -4,16 +4,6 @@ use num_traits::ToPrimitive;
 use std::{cmp::Ordering, mem::size_of};
 use winit::dpi::PhysicalSize;
 
-#[derive(AsBytes)]
-#[repr(C)]
-pub struct ScreenSpaceVertex {
-    _vertices: [f32; 2],
-}
-
-pub const fn vert(arg: [f32; 2]) -> ScreenSpaceVertex {
-    ScreenSpaceVertex { _vertices: arg }
-}
-
 #[repr(C)]
 #[derive(Clone, Copy, AsBytes, FromBytes)]
 pub struct Vertex {
@@ -117,7 +107,7 @@ pub fn create_pipeline(
         }),
         primitive_topology: PrimitiveTopology::TriangleList,
         color_states: &[ColorStateDescriptor {
-            format: TextureFormat::Bgra8Unorm,
+            format: TextureFormat::Rgba32Float,
             color_blend: BlendDescriptor::REPLACE,
             alpha_blend: BlendDescriptor::REPLACE,
             write_mask: ColorWrite::ALL,
@@ -183,7 +173,7 @@ pub fn create_framebuffer(device: &Device, size: PhysicalSize<u32>, samples: MSA
         mip_level_count: 1,
         sample_count: samples as u32,
         dimension: TextureDimension::D2,
-        format: TextureFormat::Bgra8Unorm,
+        format: TextureFormat::Rgba32Float,
         usage: TextureUsage::OUTPUT_ATTACHMENT | TextureUsage::SAMPLED,
         label: Some("framebuffer"),
     });

--- a/bve-render/src/screenspace.rs
+++ b/bve-render/src/screenspace.rs
@@ -1,0 +1,17 @@
+use wgpu::{Buffer, BufferUsage, Device};
+use zerocopy::AsBytes;
+
+#[derive(AsBytes)]
+#[repr(C)]
+pub struct ScreenSpaceVertex {
+    _vertices: [f32; 2],
+}
+
+const fn vert(arg: [f32; 2]) -> ScreenSpaceVertex {
+    ScreenSpaceVertex { _vertices: arg }
+}
+
+pub fn create_screen_space_verts(device: &Device) -> Buffer {
+    let data = [vert([-3.0, -3.0]), vert([3.0, -3.0]), vert([0.0, 3.0])];
+    device.create_buffer_with_data(data.as_bytes(), BufferUsage::VERTEX)
+}

--- a/bve-render/src/skybox.rs
+++ b/bve-render/src/skybox.rs
@@ -6,6 +6,7 @@ use zerocopy::AsBytes;
 #[repr(C)]
 pub struct SkyboxUniforms {
     _inv_view_proj: [[f32; 4]; 4],
+    _repeats: f32,
 }
 
 fn create_pipeline(device: &Device, pipeline_layout: &PipelineLayout, samples: MSAASetting) -> RenderPipeline {
@@ -64,6 +65,9 @@ pub struct Skybox {
     bind_group: BindGroup,
 
     uniform_buffer: Buffer,
+
+    pub texture_id: u64,
+    pub repeats: f32,
 }
 impl Skybox {
     pub fn new(device: &Device, texture_bind_group_layout: &BindGroupLayout, samples: MSAASetting) -> Self {
@@ -104,6 +108,8 @@ impl Skybox {
             pipeline_layout,
             bind_group,
             uniform_buffer,
+            texture_id: 0,
+            repeats: 1.0,
         }
     }
 
@@ -115,6 +121,7 @@ impl Skybox {
 
         let uniform = SkyboxUniforms {
             _inv_view_proj: *mx_inv_view_proj_bytes,
+            _repeats: self.repeats,
         };
 
         let tmp_buffer = device.create_buffer_with_data(uniform.as_bytes(), BufferUsage::COPY_SRC);
@@ -143,5 +150,12 @@ impl Skybox {
         rpass.set_bind_group(1, texture_bind_group, &[]);
         rpass.set_vertex_buffer(0, screenspace_verts, 0, 0);
         rpass.draw(0..3, 0..1);
+    }
+}
+
+impl Renderer {
+    pub fn set_skybox_image(&mut self, TextureHandle(tex_id): &TextureHandle, repeats: f32) {
+        self.skybox_renderer.texture_id = *tex_id;
+        self.skybox_renderer.repeats = repeats;
     }
 }

--- a/bve-render/src/skybox.rs
+++ b/bve-render/src/skybox.rs
@@ -1,0 +1,188 @@
+use crate::*;
+use zerocopy::AsBytes;
+
+#[derive(AsBytes)]
+#[repr(C)]
+pub struct SkyboxVertex {
+    _vertex: [f32; 3],
+}
+
+#[derive(AsBytes)]
+#[repr(C)]
+pub struct SkyboxUniforms {
+    _mvp: [f32; 16],
+    _mv: [f32; 16],
+}
+
+pub fn sb_vert(vertex: [f32; 3]) -> SkyboxVertex {
+    SkyboxVertex { _vertex: vertex }
+}
+
+pub fn create_box_buffers(device: &Device) -> (Buffer, Buffer) {
+    let vertices = [
+        sb_vert([-1.0, -1.0, 1.0]),
+        sb_vert([1.0, -1.0, 1.0]),
+        sb_vert([-1.0, 1.0, 1.0]),
+        sb_vert([1.0, 1.0, 1.0]),
+        sb_vert([-1.0, -1.0, -1.0]),
+        sb_vert([1.0, -1.0, -1.0]),
+        sb_vert([-1.0, 1.0, -1.0]),
+        sb_vert([1.0, 1.0, -1.0]),
+    ];
+
+    let indices = [0, 1, 2, 3, 7, 1, 5, 4, 7, 6, 2, 4, 0, 1];
+
+    let v_buf = device.create_buffer_with_data(vertices.as_bytes(), BufferUsage::VERTEX);
+    let i_buf = device.create_buffer_with_data(indices.as_bytes(), BufferUsage::INDEX);
+
+    (v_buf, i_buf)
+}
+
+fn create_pipeline(device: &Device, pipeline_layout: &PipelineLayout, samples: MSAASetting) -> RenderPipeline {
+    let vs = shader!(device; skybox - vert);
+    let fs = shader!(device; skybox - frag);
+    device.create_render_pipeline(&RenderPipelineDescriptor {
+        layout: pipeline_layout,
+        vertex_stage: ProgrammableStageDescriptor {
+            module: &vs,
+            entry_point: "main",
+        },
+        fragment_stage: Some(ProgrammableStageDescriptor {
+            module: &fs,
+            entry_point: "main",
+        }),
+        rasterization_state: Some(RasterizationStateDescriptor {
+            front_face: FrontFace::Ccw,
+            cull_mode: CullMode::Back,
+            depth_bias: 0,
+            depth_bias_slope_scale: 0.0,
+            depth_bias_clamp: 0.0,
+        }),
+        primitive_topology: PrimitiveTopology::TriangleStrip,
+        color_states: &[ColorStateDescriptor {
+            format: TextureFormat::Bgra8Unorm,
+            color_blend: BlendDescriptor::REPLACE,
+            alpha_blend: BlendDescriptor::REPLACE,
+            write_mask: ColorWrite::ALL,
+        }],
+        depth_stencil_state: Some(DepthStencilStateDescriptor {
+            format: TextureFormat::Depth32Float,
+            depth_write_enabled: false,
+            depth_compare: CompareFunction::GreaterEqual,
+            stencil_front: StencilStateFaceDescriptor::IGNORE,
+            stencil_back: StencilStateFaceDescriptor::IGNORE,
+            stencil_read_mask: 0,
+            stencil_write_mask: 0,
+        }),
+        vertex_state: VertexStateDescriptor {
+            index_format: IndexFormat::Uint32,
+            vertex_buffers: &[VertexBufferDescriptor {
+                stride: size_of::<SkyboxVertex>() as BufferAddress,
+                step_mode: InputStepMode::Vertex,
+                attributes: &vertex_attr_array![0 => Float3],
+            }],
+        },
+        sample_count: samples as u32,
+        sample_mask: !0,
+        alpha_to_coverage_enabled: false,
+    })
+}
+
+pub struct Skybox {
+    pipeline: RenderPipeline,
+    pipeline_layout: PipelineLayout,
+    bind_group: BindGroup,
+
+    uniform_buffer: Buffer,
+
+    vertices_buffer: Buffer,
+    indices_buffer: Buffer,
+}
+impl Skybox {
+    pub fn new(device: &Device, texture_bind_group_layout: &BindGroupLayout, samples: MSAASetting) -> Self {
+        let bind_group_layout = device.create_bind_group_layout(&BindGroupLayoutDescriptor {
+            bindings: &[BindGroupLayoutEntry {
+                binding: 0,
+                visibility: ShaderStage::VERTEX,
+                ty: BindingType::UniformBuffer { dynamic: false },
+            }],
+            label: Some("skybox"),
+        });
+
+        let pipeline_layout = device.create_pipeline_layout(&PipelineLayoutDescriptor {
+            bind_group_layouts: &[&bind_group_layout, texture_bind_group_layout],
+        });
+        let pipeline = create_pipeline(device, &pipeline_layout, samples);
+
+        let uniform_buffer = device.create_buffer(&BufferDescriptor {
+            size: size_of::<SkyboxUniforms>() as BufferAddress,
+            usage: BufferUsage::UNIFORM | BufferUsage::COPY_DST,
+            label: Some("skybox uniform"),
+        });
+
+        let bind_group = device.create_bind_group(&BindGroupDescriptor {
+            layout: &bind_group_layout,
+            bindings: &[Binding {
+                binding: 0,
+                resource: BindingResource::Buffer {
+                    buffer: &uniform_buffer,
+                    range: 0..(size_of::<SkyboxUniforms>() as BufferAddress),
+                },
+            }],
+            label: Some("skybox"),
+        });
+
+        let (vertices_buffer, indices_buffer) = create_box_buffers(device);
+
+        Self {
+            pipeline,
+            pipeline_layout,
+            bind_group,
+            uniform_buffer,
+            vertices_buffer,
+            indices_buffer,
+        }
+    }
+
+    pub fn update(
+        &mut self,
+        device: &Device,
+        encoder: &mut CommandEncoder,
+        camera: &camera::Camera,
+        mx_proj: &Matrix4<f32>,
+    ) {
+        let mx_view = camera.compute_origin_matrix();
+        // Everything is at 0.0, so we care only about V and P
+        let mx_mvp = mx_proj * Matrix4::from(mx_view);
+        let mx_view_bytes: &[f32; 16] = mx_proj.as_ref();
+        let mx_mvp_bytes: &[f32; 16] = mx_mvp.as_ref();
+
+        let uniform = SkyboxUniforms {
+            _mvp: mx_mvp_bytes.clone(),
+            _mv: mx_view_bytes.clone(),
+        };
+
+        let tmp_buffer = device.create_buffer_with_data(uniform.as_bytes(), BufferUsage::COPY_SRC);
+
+        encoder.copy_buffer_to_buffer(
+            &tmp_buffer,
+            0,
+            &self.uniform_buffer,
+            0,
+            size_of::<SkyboxUniforms>() as BufferAddress,
+        );
+    }
+
+    pub fn set_samples(&mut self, device: &Device, samples: MSAASetting) {
+        self.pipeline = create_pipeline(device, &self.pipeline_layout, samples);
+    }
+
+    pub fn render_skybox<'a>(&'a self, rpass: &mut RenderPass<'a>, texture_bind_group: &'a BindGroup) {
+        rpass.set_pipeline(&self.pipeline);
+        rpass.set_bind_group(0, &self.bind_group, &[]);
+        rpass.set_bind_group(1, &texture_bind_group, &[]);
+        rpass.set_vertex_buffer(0, &self.vertices_buffer, 0, 0);
+        rpass.set_index_buffer(&self.indices_buffer, 0, 0);
+        rpass.draw_indexed(0..14, 0, 0..1);
+    }
+}

--- a/bve-render/src/skybox.rs
+++ b/bve-render/src/skybox.rs
@@ -38,7 +38,7 @@ fn create_pipeline(device: &Device, pipeline_layout: &PipelineLayout, samples: M
         depth_stencil_state: Some(DepthStencilStateDescriptor {
             format: TextureFormat::Depth32Float,
             depth_write_enabled: false,
-            depth_compare: CompareFunction::Always,
+            depth_compare: CompareFunction::LessEqual,
             stencil_front: StencilStateFaceDescriptor::IGNORE,
             stencil_back: StencilStateFaceDescriptor::IGNORE,
             stencil_read_mask: 0,

--- a/bve-render/src/skybox.rs
+++ b/bve-render/src/skybox.rs
@@ -29,7 +29,7 @@ fn create_pipeline(device: &Device, pipeline_layout: &PipelineLayout, samples: M
             depth_bias_slope_scale: 0.0,
             depth_bias_clamp: 0.0,
         }),
-        primitive_topology: PrimitiveTopology::TriangleStrip,
+        primitive_topology: PrimitiveTopology::TriangleList,
         color_states: &[ColorStateDescriptor {
             format: TextureFormat::Rgba32Float,
             color_blend: BlendDescriptor::REPLACE,

--- a/bve-render/src/texture.rs
+++ b/bve-render/src/texture.rs
@@ -1,5 +1,6 @@
 use crate::*;
 use image::{Rgba, RgbaImage};
+use nalgebra_glm::make_vec2;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TextureHandle(pub(crate) u64);
@@ -30,7 +31,7 @@ impl Renderer {
             height: image.height(),
             depth: 1,
         };
-        let mip_levels = render::mip_levels(Vector2::new(image.width(), image.height()));
+        let mip_levels = render::mip_levels(make_vec2(&[image.width(), image.height()]));
         let mut texture_descriptor = TextureDescriptor {
             size: extent,
             array_layer_count: 1,
@@ -67,7 +68,7 @@ impl Renderer {
 
         texture_descriptor.mip_level_count = mip_levels;
         let filtered_texture = self.device.create_texture(&texture_descriptor);
-        let dimensions = Vector2::new(image.width(), image.height());
+        let dimensions = make_vec2(&[image.width(), image.height()]);
         let transparent_command = self.transparency_processor.compute_transparency(
             &self.device,
             &base_texture,

--- a/bve/Cargo.toml
+++ b/bve/Cargo.toml
@@ -35,6 +35,7 @@ indexmap = "1.2"
 itertools = "0.9"
 locale_config = "0.3.0"
 log = "0.4.8"
+nalgebra-glm = "0.7.0"
 nom = { version = "5.1.0", default-features = false, features = ["alloc"] }
 num-traits = "0.2.11"
 once_cell = "1.3.1"

--- a/bve/src/runtime/client.rs
+++ b/bve/src/runtime/client.rs
@@ -1,6 +1,6 @@
 use crate::load::mesh::Vertex;
-use cgmath::Vector3;
 use image::RgbaImage;
+use nalgebra_glm::Vec3;
 use std::hash::Hash;
 
 pub trait Client: Send + Sync + 'static {
@@ -8,10 +8,10 @@ pub trait Client: Send + Sync + 'static {
     type MeshHandle: Clone + Hash + Send + Sync + 'static;
     type TextureHandle: Clone + Default + Hash + Send + Sync + 'static;
 
-    fn add_object(&mut self, location: Vector3<f32>, mesh: &Self::MeshHandle) -> Self::ObjectHandle;
+    fn add_object(&mut self, location: Vec3, mesh: &Self::MeshHandle) -> Self::ObjectHandle;
     fn add_object_texture(
         &mut self,
-        location: Vector3<f32>,
+        location: Vec3,
         mesh: &Self::MeshHandle,
         texture: &Self::TextureHandle,
     ) -> Self::ObjectHandle;
@@ -22,6 +22,6 @@ pub trait Client: Send + Sync + 'static {
     fn remove_mesh(&mut self, mesh: &Self::MeshHandle);
     fn remove_texture(&mut self, texture: &Self::TextureHandle);
 
-    fn set_camera_location(&mut self, location: Vector3<f32>);
-    fn set_object_location(&mut self, object: &Self::ObjectHandle, location: Vector3<f32>);
+    fn set_camera_location(&mut self, location: Vec3);
+    fn set_object_location(&mut self, object: &Self::ObjectHandle, location: Vec3);
 }

--- a/bve/src/runtime/mod.rs
+++ b/bve/src/runtime/mod.rs
@@ -18,6 +18,7 @@ use futures::{
 };
 use hecs::World;
 use log::{debug, trace};
+use nalgebra_glm::make_vec3;
 use std::sync::atomic::{AtomicI32, Ordering};
 
 macro_rules! async_clone_own {
@@ -174,7 +175,11 @@ impl<C: Client> Runtime<C> {
                 let location = Location::from_address_position(chunk.address, chunk_offset);
                 let render_location = location.to_relative_position(base_chunk);
 
-                let object_handle = client.add_object_texture(render_location, &mesh_handle, &texture_handle);
+                let object_handle = client.add_object_texture(
+                    make_vec3(&[render_location.x, render_location.y, render_location.z]),
+                    &mesh_handle,
+                    &texture_handle,
+                );
                 object_textures.push(RenderableObject {
                     object: object_handle,
                     location,
@@ -248,7 +253,7 @@ impl<C: Client> Runtime<C> {
         runtime_location.location = location;
         drop(runtime_location);
         let mut client = self.client.lock().await;
-        client.set_camera_location(*location.offset);
+        client.set_camera_location(make_vec3(&[location.offset.x, location.offset.y, location.offset.z]));
     }
 
     async fn update_camera_position(self: Arc<Self>, base_location: Location) {
@@ -259,7 +264,10 @@ impl<C: Client> Runtime<C> {
             let renderable: &RenderableComponent<C> = renderable;
             for object in &renderable.subobjects {
                 let render_location = object.location.to_relative_position(base_location.chunk);
-                client.set_object_location(&object.object, render_location);
+                client.set_object_location(
+                    &object.object,
+                    make_vec3(&[render_location.x, render_location.y, render_location.z]),
+                );
             }
         }
     }


### PR DESCRIPTION
This adds a skybox using openbve's skybox style. This is quite annoying and has a bug in it that I know fuckall how to fix.

Other changes:
- Changed from cgmath to nalgebra-glm inside the renderer, completely nuking debug performance, but making everything work.

Future Work:
- Fix the damn bug or:
- Turn the bve skybox into a cubemap and just use that.
- Support cubemaps in general.
- Support fading between backgrounds.