### PR TITLE
Assorted Fixes

### DIFF
--- a/bve-build/src/main.rs
+++ b/bve-build/src/main.rs
@@ -361,12 +361,13 @@ fn main() {
 
     let all =
         !(options.cbindgen || options.build || options.shaderc || options.native || options.client || options.core);
+    let should_build = options.build || options.native || options.client || options.core || all;
 
     if options.shaderc || options.client || all {
         build_shaders();
     }
 
-    if options.build || all {
+    if should_build {
         build(&options);
     }
 

--- a/bve-build/src/main.rs
+++ b/bve-build/src/main.rs
@@ -359,17 +359,18 @@ fn main() {
         exit(1);
     }
 
-    let all = !(options.cbindgen || options.build || options.shaderc);
+    let all =
+        !(options.cbindgen || options.build || options.shaderc || options.native || options.client || options.core);
+
+    if options.shaderc || options.client || all {
+        build_shaders();
+    }
 
     if options.build || all {
         build(&options);
     }
 
-    if options.cbindgen || all {
+    if options.cbindgen || options.native || all {
         generate_c_bindings();
-    }
-
-    if options.shaderc || all {
-        build_shaders();
     }
 }

--- a/bve-build/src/main.rs
+++ b/bve-build/src/main.rs
@@ -51,7 +51,7 @@
 use crate::shaders::{ShaderCombination, ShaderType, SingleDefine};
 use itertools::Itertools;
 use std::{
-    fs::{create_dir_all, metadata, read_to_string, remove_dir_all},
+    fs::{create_dir_all, metadata, read_dir, read_to_string, remove_dir_all},
     path::Path,
     process::{exit, Command},
 };
@@ -103,6 +103,16 @@ fn out_of_date(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> bool {
         .expect("Destination must have modified time");
 
     src_time > dst_time
+}
+
+fn headers_out_of_date(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> bool {
+    for element in read_dir("bve-render/shaders/include").expect("could not find include dir") {
+        let element = element.expect("has no element");
+        if out_of_date(element.path(), src.as_ref()) && out_of_date(element.path(), dst.as_ref()) {
+            return true;
+        }
+    }
+    return false;
 }
 
 fn build(options: &Options) {
@@ -247,7 +257,7 @@ fn build_shaders() {
             .collect_vec();
 
         {
-            if out_of_date(&source_name, &spirv_name) {
+            if out_of_date(&source_name, &spirv_name) || headers_out_of_date(&source_name, &spirv_name) {
                 println!("Compiling {} to {}", source_name, spirv_name);
 
                 let mut flags = define_flags.clone();
@@ -275,7 +285,7 @@ fn build_shaders() {
         {
             let spirv_name_opt = spirv_name + ".opt";
 
-            if out_of_date(&source_name, &spirv_name_opt) {
+            if out_of_date(&source_name, &spirv_name_opt) || headers_out_of_date(&source_name, &spirv_name_opt) {
                 println!("Compiling {} to {}", source_name, spirv_name_opt);
 
                 let mut flags = define_flags.clone();

--- a/bve-build/src/main.rs
+++ b/bve-build/src/main.rs
@@ -112,7 +112,7 @@ fn headers_out_of_date(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> bool {
             return true;
         }
     }
-    return false;
+    false
 }
 
 fn build(options: &Options) {

--- a/bve-client/src/main.rs
+++ b/bve-client/src/main.rs
@@ -275,7 +275,7 @@ fn client_main() {
                     .add_light(LightDescriptor {
                         location: Location::from_absolute_position(Vec3::new(
                             x as f32 * (42.0 / LIGHTS_X as f32),
-                            10.0,
+                            0.0,
                             y as f32 * (480.0 / LIGHTS_Y as f32),
                         )),
                         radius: 10.0,
@@ -291,7 +291,7 @@ fn client_main() {
         }
         runtime
             .add_light(LightDescriptor {
-                location: Location::from_absolute_position(Vec3::new(8.0, 10.0, 0.0)),
+                location: Location::from_absolute_position(Vec3::new(8.0, 0.0, 0.0)),
                 radius: 10.0,
                 color: Vec3::one(),
                 ty: LightType::Point,

--- a/bve-render/shaders/include/do_lighting.glsl
+++ b/bve-render/shaders/include/do_lighting.glsl
@@ -3,54 +3,78 @@
 
 #include "opaque_signature.glsl"
 #include "lights.glsl"
+#include "gamma.glsl"
 
-vec3 light_with_light(ConeLight light, vec3 object_color) {
+#define SPECULAR       0x0001
+#define SPECULAR_COLOR 0x0010
+#define DIFFUSE        0x0100
+#define AMBIENT        0x1000
+
+vec3 light_with_light(ConeLight light, vec3 object_color, int features) {
     if (bool(light.point)) {
+        vec3 light_accumulator = vec3(0.0);
 
-        // diffuse
         vec3 light_dir_unnorm = light.location.xyz - view_position.xyz;
         vec3 light_dir = normalize(light_dir_unnorm);
         vec3 normal_ized = normalize(normal);
-        float diff = max(dot(light_dir, normal_ized), 0.0);
-        vec3 diffuse = diff * object_color;
+        if (bool(features & DIFFUSE)) {
+            // diffuse
+            float diff = max(dot(light_dir, normal_ized), 0.0);
+            vec3 diffuse = diff * object_color;
+            light_accumulator += diffuse;
+        }
 
-        // specular
-        vec3 view_dir = normalize(-view_position.xyz);
-        vec3 reflect_dir = reflect(-light_dir, normal_ized);
-        vec3 halfway_dir = normalize(light_dir + view_dir);
-        vec3 specular = pow(max(dot(normal_ized, halfway_dir), 0.0), 32.0) * vec3(0.3); // fix constant
+        if (bool(features & SPECULAR)) {
+            // specular
+            vec3 view_dir = normalize(-view_position.xyz);
+            vec3 reflect_dir = reflect(-light_dir, normal_ized);
+            vec3 halfway_dir = normalize(light_dir + view_dir);
+            vec3 specular = vec3(pow(max(dot(normal_ized, halfway_dir), 0.0), 32.0));
+            if (bool(features & SPECULAR_COLOR)) {
+                specular *= object_color;
+            }
+            light_accumulator += specular;
+        }
 
         // attenuation
         float distance = length(light_dir_unnorm);
         float attenuation = clamp(1.0 - (distance * distance) / (light.radius * light.radius), 0.0, 1.0);
         attenuation *= attenuation;
 
-        return light.color.rgb * attenuation * (specular + diffuse);
+        return light.color.rgb * attenuation * light_accumulator;
     } else {
         return vec3(0.0);
     }
 }
 
-vec4 do_lighting() {
+vec4 do_lighting(int features) {
     uvec3 froxel = compute_froxel();
     uint froxel_index = get_cluster_list_index(froxel, froxel_count);
 
-    vec4 texture_color_srgb = texture(usampler2D(color_texture, main_sampler), texcoord);
-    vec4 texture_color = vec4(pow(texture_color_srgb.rgb / 255, vec3(2.2)), texture_color_srgb.a);
-    vec3 object_color = texture_color.rgb * mesh_color.rgb;
+    uvec4 texture_color_srgb = texture(usampler2D(color_texture, main_sampler), texcoord);
+    vec4 texture_color = srgb_to_linear(rgbaU8_to_rgbaF32(texture_color_srgb));
+    vec4 object_color = texture_color * mesh_color;
 
     vec3 light_accumulation = vec3(0.0);
 
     uint count = light_index_list[froxel_index].count;
     for (uint l = 0; l < count; ++l) {
-        light_accumulation += light_with_light(lights[light_index_list[froxel_index].indices[l]], object_color);
+        light_accumulation += light_with_light(lights[light_index_list[froxel_index].indices[l]], object_color.rgb, features);
     }
 
-    // ambient
-    vec3 ambient = object_color * 0.05;
-    light_accumulation += ambient;
+    if (bool(features & AMBIENT)) {
+        // ambient
+        float factor;
+        if (bool(features & SPECULAR_COLOR)) {
+            factor = 1.0;
+        } else {
+            factor = 0.5;
+        }
+        vec3 ambient = object_color.rgb * factor;
+        light_accumulation += ambient;
+    }
 
-    return vec4(light_accumulation, texture_color.a);
+    return vec4(light_accumulation, object_color.a);
 }
 
 #endif

--- a/bve-render/shaders/include/do_lighting.glsl
+++ b/bve-render/shaders/include/do_lighting.glsl
@@ -68,7 +68,7 @@ vec4 do_lighting(int features) {
         if (bool(features & SPECULAR_COLOR)) {
             factor = 1.0;
         } else {
-            factor = 0.5;
+            factor = 0.05;
         }
         vec3 ambient = object_color.rgb * factor;
         light_accumulation += ambient;

--- a/bve-render/shaders/include/do_lighting.glsl
+++ b/bve-render/shaders/include/do_lighting.glsl
@@ -5,8 +5,9 @@
 #include "lights.glsl"
 #include "gamma.glsl"
 
+// Flags to enable various lighting features when calling do_lighting()
 #define SPECULAR       0x0001
-#define SPECULAR_COLOR 0x0010
+#define SPECULAR_COLOR 0x0010 // Object's color is used in specular
 #define DIFFUSE        0x0100
 #define AMBIENT        0x1000
 

--- a/bve-render/shaders/oit_pass1.fs.glsl
+++ b/bve-render/shaders/oit_pass1.fs.glsl
@@ -24,8 +24,7 @@ layout(set = 2, binding = 2, std430) buffer NodeBuffer {
 };
 
 void main() {
-    vec4 tex_color = srgb_to_linear(rgbaU8_to_rgbaF32(texture(usampler2D(color_texture, main_sampler), texcoord)));
-    vec4 color = tex_color * mesh_color;
+    vec4 color = do_lighting(AMBIENT | SPECULAR | SPECULAR_COLOR | DIFFUSE);
 
     if (color.a <= 0.0) {
         discard;

--- a/bve-render/shaders/oit_pass2.fs.glsl
+++ b/bve-render/shaders/oit_pass2.fs.glsl
@@ -13,10 +13,13 @@ struct Node {
     uint next;
 };
 
-layout(set = 0, binding = 0, r32ui) uniform uimage2D head_pointers;
+layout(set = 0, binding = 0) buffer HeadPointers {
+    uint head_pointers[];
+};
 layout(set = 0, binding = 1) uniform OIT {
     uint max_nodes;
     uint samples;
+    uvec2 screen_size;
 };
 layout(set = 0, binding = 2, std430) buffer NodeBuffer {
     uint next_index;
@@ -32,8 +35,9 @@ layout(set = 1, binding = 1) uniform sampler framebuffer_sampler;
 void main() {
     Node frags[MAX_NODES];
 
-    uint n = imageLoad(head_pointers, ivec2(gl_FragCoord.xy)).r;
-    imageStore(head_pointers, ivec2(gl_FragCoord.xy), uvec4(0xFFFFFFFF));
+    uint index = uint(gl_FragCoord.x) * screen_size.y + uint(gl_FragCoord.y);
+    uint n = head_pointers[index];
+    head_pointers[index] = 0xFFFFFFFF;
 
     int count = 0;
     for(; n != 0xFFFFFFFF && count < MAX_NODES; ++count) {

--- a/bve-render/shaders/opaque.fs.glsl
+++ b/bve-render/shaders/opaque.fs.glsl
@@ -4,7 +4,7 @@
 #include "do_lighting.glsl"
 
 void main() {
-    vec4 color = do_lighting();
+    vec4 color = do_lighting(SPECULAR | DIFFUSE | AMBIENT);
     if (color.a <= 0.5) {
         discard;
     } else {

--- a/bve/src/runtime/cache/mesh.rs
+++ b/bve/src/runtime/cache/mesh.rs
@@ -87,9 +87,9 @@ impl<C: Client> MeshCache<C> {
         }
 
         for texture in raw_mesh_data.textures {
-            let path = resolve_path(parent_dir, PathBuf::from(texture))
+            let path = resolve_path(parent_dir, PathBuf::from(&texture))
                 .await
-                .expect("Could not find texture");
+                .unwrap_or_else(|| panic!("Could not find texture {}", texture));
             mesh_data.textures.push(path_set.insert(path).await);
         }
 


### PR DESCRIPTION
This solves a couple outstanding issues:

- Build system rebuilds shaders when headers change
- Lighting now effects transparency
- Moved to buffers instead of storage texture to make metal shaders compile.
- Fix options in the build system
- Tell what texture is missing if you can't find a texture